### PR TITLE
Add word cloud visualization for Top Terms

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -7,7 +7,8 @@
       "name": "vibe-wrapper-dashboard",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "wordcloud": "^1.2.3"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",
@@ -2722,6 +2723,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/wordcloud": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/wordcloud/-/wordcloud-1.2.3.tgz",
+      "integrity": "sha512-9by77b7Sd9e1K75kSmVeAD+JnGpiLR1Z4EX1mYQL91jKrU1/4bHw4h4DExQ+dzfT+PvihDcH7OS7V4Y5UkbF2w==",
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "wordcloud": "^1.2.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",

--- a/dashboard/src/components/WordCloud.jsx
+++ b/dashboard/src/components/WordCloud.jsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useRef } from "react";
-import "wordcloud";
+import WordCloudLib from "wordcloud";
 
 export default function WordCloud({ words, width = 600, height = 400, className = "" }) {
   const canvasRef = useRef(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas || !words || words.length === 0) return;
+    const draw = WordCloudLib || window.WordCloud;
+    if (!canvas || !words || words.length === 0 || typeof draw !== "function") return;
 
     const list = words.map(({ term, count }) => [term, count]);
     const max = list[0]?.[1] || 1;
@@ -19,7 +20,7 @@ export default function WordCloud({ words, width = 600, height = 400, className 
     const ctx = canvas.getContext("2d");
     ctx.scale(dpr, dpr);
 
-    window.WordCloud(canvas, {
+    draw(canvas, {
       list,
       gridSize: Math.round((16 * width) / 1024),
       weightFactor: (w) => (w / max) * (Math.min(width, height) / 8),
@@ -42,7 +43,6 @@ export default function WordCloud({ words, width = 600, height = 400, className 
     });
 
     return () => {
-      // WordCloud doesn't have a destroy method, just clear
       const dpr = window.devicePixelRatio || 1;
       ctx && ctx.clearRect(0, 0, width * dpr, height * dpr);
     };

--- a/dashboard/src/components/WordCloud.jsx
+++ b/dashboard/src/components/WordCloud.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useRef } from "react";
+import "wordcloud";
+
+export default function WordCloud({ words, width = 600, height = 400, className = "" }) {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !words || words.length === 0) return;
+
+    const list = words.map(({ term, count }) => [term, count]);
+    const max = list[0]?.[1] || 1;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = width + "px";
+    canvas.style.height = height + "px";
+    const ctx = canvas.getContext("2d");
+    ctx.scale(dpr, dpr);
+
+    window.WordCloud(canvas, {
+      list,
+      gridSize: Math.round((16 * width) / 1024),
+      weightFactor: (w) => (w / max) * (Math.min(width, height) / 8),
+      fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+      color: () => {
+        const colors = [
+          "#059669", "#10b981", "#34d399", "#047857", "#065f46",
+          "#8b5cf6", "#6366f1", "#3b82f6", "#f59e0b", "#ec4899",
+        ];
+        return colors[Math.floor(Math.random() * colors.length)];
+      },
+      rotateRatio: 0.3,
+      minRotation: -0.5,
+      maxRotation: 0.5,
+      backgroundColor: "transparent",
+      shuffle: false,
+      shape: "circle",
+      ellipticity: 1.0,
+      clearCanvas: true,
+    });
+
+    return () => {
+      // WordCloud doesn't have a destroy method, just clear
+      const dpr = window.devicePixelRatio || 1;
+      ctx && ctx.clearRect(0, 0, width * dpr, height * dpr);
+    };
+  }, [words, width, height]);
+
+  if (!words || words.length === 0) {
+    return <p className="text-body-sm text-neutral-500">No terms to display</p>;
+  }
+
+  return (
+    <div className={`flex justify-center ${className}`}>
+      <canvas ref={canvasRef} className="max-w-full" />
+    </div>
+  );
+}

--- a/dashboard/src/components/WordCloud.jsx
+++ b/dashboard/src/components/WordCloud.jsx
@@ -6,7 +6,7 @@ export default function WordCloud({ words, width = 600, height = 400, className 
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    const draw = WordCloudLib || window.WordCloud;
+    const draw = WordCloudLib?.default || WordCloudLib || window.WordCloud;
     if (!canvas || !words || words.length === 0 || typeof draw !== "function") return;
 
     const list = words.map(({ term, count }) => [term, count]);

--- a/dashboard/src/pages/Overview.jsx
+++ b/dashboard/src/pages/Overview.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Card, Badge, MetricDisplay } from "../ui";
 import { useApi, SkeletonCard, SkeletonMetric } from "../hooks/useApi.jsx";
+import WordCloud from "../components/WordCloud.jsx";
 
 const CATEGORY_LABELS = {
   planning: "Planning",
@@ -114,20 +115,10 @@ export default function Overview() {
         </Card>
       </div>
 
-      {/* Top Terms */}
+      {/* Word Cloud */}
       {word_frequencies && word_frequencies.length > 0 && (
-        <Card title="Top Terms" subtitle="Most frequent terms in useful prompts">
-          <div className="flex flex-wrap gap-2">
-            {word_frequencies.slice(0, 24).map(({ term, count }) => (
-              <span
-                key={term}
-                className="inline-flex items-center px-3 py-1.5 rounded-full text-body-sm font-medium bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 hover:bg-brand-50 dark:hover:bg-brand-950 hover:text-brand-700 dark:hover:text-brand-300 transition-colors"
-                style={{ fontSize: `${Math.max(12, 14 + Math.log2(count))}px` }}
-              >
-                {term}
-              </span>
-            ))}
-          </div>
+        <Card title="Word Cloud" subtitle="Most frequent terms in useful prompts">
+          <WordCloud words={word_frequencies} />
         </Card>
       )}
 


### PR DESCRIPTION
Replace flat tag list with Canvas-based word cloud using wordcloud2.js (zero dependencies). Brand-green + accent colors, circular layout, HiDPI rendering.