### PR TITLE
fix(extract): improve prompt artifact provenance

### DIFF
--- a/.agents/memory/data-sources-and-limitations.md
+++ b/.agents/memory/data-sources-and-limitations.md
@@ -1,6 +1,6 @@
 # Data sources and limitations
 
-Last updated: 2026-07-29
+Last updated: 2026-08-05
 
 ## Normalized source contract
 
@@ -56,6 +56,7 @@ Prompt adapters return a report shaped like:
 - Codex extraction removes known desktop-owned envelopes, including recommended-plugin, environment, app-context, permission, skills, and `AGENTS.md` instruction blocks, while preserving the authored request that follows them.
 - `profile_signals.prompt_analysis` classifies useful intent separately from pasted code/log reference material.
 - Structured attachments have ambiguous provenance. Code, config, diffs, logs, terminal output, prompt templates, and opaque text are separated from the surrounding request. Separable actionable prose around code, config, diffs, logs, or terminal output is retained while unknown material origin stays `unverified`; explicit self-authorship or external/generated provenance is recorded separately. Only stripped request text affects profile statistics. Pure code without request prose, source-unknown templates, and opaque text remain reference evidence.
+- Actionable prose includes imperative and interrogative requests in English or Chinese. Terminal blocks and unfenced code are stripped as attachment regions so their stdout and code keywords cannot influence categories or word statistics.
 - Word frequencies use the complete useful-for-stats collection, prefer timestamped prompts when available, and remove fenced code, local paths, HTML/CSS/code-heavy lines, identifier noise, and stop words.
 
 ## Privacy boundary

--- a/.agents/memory/data-sources-and-limitations.md
+++ b/.agents/memory/data-sources-and-limitations.md
@@ -1,6 +1,6 @@
 # Data sources and limitations
 
-Last updated: 2026-07-26
+Last updated: 2026-07-29
 
 ## Normalized source contract
 
@@ -53,7 +53,9 @@ Prompt adapters return a report shaped like:
 ## Prompt hygiene
 
 - Codex assistant/tool events, Claude tool-result blocks, Cursor assistant/system bubbles, and generic system/tool notifications are excluded before aggregation.
+- Codex extraction removes known desktop-owned envelopes, including recommended-plugin, environment, app-context, permission, skills, and `AGENTS.md` instruction blocks, while preserving the authored request that follows them.
 - `profile_signals.prompt_analysis` classifies useful intent separately from pasted code/log reference material.
+- Structured attachments have ambiguous provenance. Code, config, diffs, logs, terminal output, prompt templates, and opaque text are separated from the surrounding request. Separable actionable prose around code, config, diffs, logs, or terminal output is retained while unknown material origin stays `unverified`; explicit self-authorship or external/generated provenance is recorded separately. Only stripped request text affects profile statistics. Pure code without request prose, source-unknown templates, and opaque text remain reference evidence.
 - Word frequencies use the complete useful-for-stats collection, prefer timestamped prompts when available, and remove fenced code, local paths, HTML/CSS/code-heavy lines, identifier noise, and stop words.
 
 ## Privacy boundary

--- a/.agents/spec/profile-signal-extractor.md
+++ b/.agents/spec/profile-signal-extractor.md
@@ -2,7 +2,7 @@
 
 Status: completed
 Created: 2026-06-08
-Last updated: 2026-07-23
+Last updated: 2026-07-29
 
 ## Goal
 
@@ -26,3 +26,5 @@ Implemented `profile_signals` in the inspect report. It now includes useful/refe
 PR #6 made these signals inputs to the six-axis `vibe_profile`. Subsequent prompt-hygiene work keeps the complete useful prompt set for statistics while bounding displayed examples, prefers timestamped prompts for word clouds, and excludes assistant/tool/system text plus pasted code and path noise.
 
 Word-cloud ranking now treats distinct-prompt coverage as the primary relevance signal and gives repetition inside one prompt only a logarithmic bonus. The report retains raw `count` and adds `prompt_count` plus display `weight`. Chinese segmentation combines `Intl.Segmenter` with a compact developer-term vocabulary, and common bilingual concept variants are grouped before ranking. UI rendering narrows the vocabulary to coding-domain terms and specific behavioral categories, omits the generic Implementation fallback, and collapses lexical/category duplicates. Unknown recurring terms can be promoted as project-domain entities using independent-Prompt coverage, mentions per Prompt, time concentration, and observed-acronym signals; casing such as `HIT` is preserved. Lightweight `word_cloud_records` let Usage Analytics rebuild the cloud for Day/Week/Month/Total/Custom and Agent filters, while a lifetime domain index keeps established entities eligible in narrow selections.
+
+Structured-material classification is deliberately provenance-conservative. The extractor recognizes code in any language, configuration data, patches, logs, terminal output, prompt templates, and opaque encoded/minified text. A separable actionable request around code, config, diffs, logs, or terminal output is retained even when the material's origin is unknown; the material remains an unverified attached reference and does not become authorship evidence. Explicit self-authorship or external/generated provenance is recorded separately. Only stripped request text contributes to categories, word statistics, average length, and long-prompt ratio. Pure code without request prose, source-unknown prompt templates, and opaque material remain reference evidence. App-owned envelopes such as recommended-plugin lists, environment context, and injected `AGENTS.md` instructions are always excluded.

--- a/.agents/spec/profile-signal-extractor.md
+++ b/.agents/spec/profile-signal-extractor.md
@@ -2,7 +2,7 @@
 
 Status: completed
 Created: 2026-06-08
-Last updated: 2026-07-29
+Last updated: 2026-08-05
 
 ## Goal
 
@@ -28,3 +28,5 @@ PR #6 made these signals inputs to the six-axis `vibe_profile`. Subsequent promp
 Word-cloud ranking now treats distinct-prompt coverage as the primary relevance signal and gives repetition inside one prompt only a logarithmic bonus. The report retains raw `count` and adds `prompt_count` plus display `weight`. Chinese segmentation combines `Intl.Segmenter` with a compact developer-term vocabulary, and common bilingual concept variants are grouped before ranking. UI rendering narrows the vocabulary to coding-domain terms and specific behavioral categories, omits the generic Implementation fallback, and collapses lexical/category duplicates. Unknown recurring terms can be promoted as project-domain entities using independent-Prompt coverage, mentions per Prompt, time concentration, and observed-acronym signals; casing such as `HIT` is preserved. Lightweight `word_cloud_records` let Usage Analytics rebuild the cloud for Day/Week/Month/Total/Custom and Agent filters, while a lifetime domain index keeps established entities eligible in narrow selections.
 
 Structured-material classification is deliberately provenance-conservative. The extractor recognizes code in any language, configuration data, patches, logs, terminal output, prompt templates, and opaque encoded/minified text. A separable actionable request around code, config, diffs, logs, or terminal output is retained even when the material's origin is unknown; the material remains an unverified attached reference and does not become authorship evidence. Explicit self-authorship or external/generated provenance is recorded separately. Only stripped request text contributes to categories, word statistics, average length, and long-prompt ratio. Pure code without request prose, source-unknown prompt templates, and opaque material remain reference evidence. App-owned envelopes such as recommended-plugin lists, environment context, and injected `AGENTS.md` instructions are always excluded.
+
+Follow-up hardening retains common English and Chinese interrogative requests around attachments, strips complete terminal-output regions, and removes unfenced declaration/return/throw code shapes before category inference.

--- a/src/extract/phrase-stats.js
+++ b/src/extract/phrase-stats.js
@@ -392,7 +392,9 @@ const CONCEPT_GROUPS = [
 ];
 
 const CONCEPT_BY_TERM = new Map(
-  CONCEPT_GROUPS.flatMap(([concept, terms]) => terms.map((term) => [term, `concept:${concept}`])),
+  CONCEPT_GROUPS.flatMap(([concept, terms]) =>
+    terms.map((term) => [term, `concept:${concept}`]),
+  ),
 );
 const CATEGORY_BY_CONCEPT = new Map([
   ["concept:testing", "category:testing"],
@@ -463,7 +465,8 @@ function wordCloudRecords(prompts = []) {
       };
       existing.vibe = existing.vibe || isVibeCodingTerm(term);
       existing.acronym = existing.acronym || acronym;
-      existing.variants[displayTerm] = (existing.variants[displayTerm] || 0) + 1;
+      existing.variants[displayTerm] =
+        (existing.variants[displayTerm] || 0) + 1;
       byConcept.set(key, existing);
     }
     for (const category of prompt.categories || []) {
@@ -485,7 +488,10 @@ function wordCloudRecords(prompts = []) {
   });
 }
 
-function wordFrequenciesFromRecords(records = [], { limit = 30, vibeOnly = false } = {}) {
+function wordFrequenciesFromRecords(
+  records = [],
+  { limit = 30, vibeOnly = false } = {},
+) {
   const concepts = new Map();
   for (const record of records) {
     for (const item of record.concepts || []) {
@@ -503,7 +509,10 @@ function wordFrequenciesFromRecords(records = [], { limit = 30, vibeOnly = false
       for (const [term, rawCount] of Object.entries(item.variants || {})) {
         const count = Math.max(0, Number(rawCount) || 0);
         if (count === 0) continue;
-        const variant = concept.variants.get(term) || { count: 0, prompt_count: 0 };
+        const variant = concept.variants.get(term) || {
+          count: 0,
+          prompt_count: 0,
+        };
         conceptCount += count;
         variant.count += count;
         variant.prompt_count += 1;
@@ -528,8 +537,10 @@ function wordFrequenciesFromRecords(records = [], { limit = 30, vibeOnly = false
       // only a small logarithmic boost, so pasted/verbose prompts cannot dominate.
       const repetition = Math.max(0, concept.count - concept.prompt_count);
       const weight = Number(
-        ((concept.prompt_count + Math.log2(1 + repetition) * 0.35)
-          * (concept.kind === "category" ? 1.12 : 1)).toFixed(3),
+        (
+          (concept.prompt_count + Math.log2(1 + repetition) * 0.35) *
+          (concept.kind === "category" ? 1.12 : 1)
+        ).toFixed(3),
       );
       return {
         key: concept.key,
@@ -540,14 +551,22 @@ function wordFrequenciesFromRecords(records = [], { limit = 30, vibeOnly = false
         weight,
       };
     })
-    .sort((a, b) => b.weight - a.weight || b.prompt_count - a.prompt_count || b.count - a.count || a.term.localeCompare(b.term))
+    .sort(
+      (a, b) =>
+        b.weight - a.weight ||
+        b.prompt_count - a.prompt_count ||
+        b.count - a.count ||
+        a.term.localeCompare(b.term),
+    )
     .slice(0, limit);
 }
 
 function isAcronymUse(term, text) {
   if (!/^[a-z][a-z0-9]{1,5}$/.test(term)) return false;
   const upper = term.toUpperCase();
-  return new RegExp(`(^|[^A-Za-z0-9])${upper}(?=$|[^A-Za-z0-9])`).test(String(text || ""));
+  return new RegExp(`(^|[^A-Za-z0-9])${upper}(?=$|[^A-Za-z0-9])`).test(
+    String(text || ""),
+  );
 }
 
 function isVibeCodingTerm(term) {
@@ -557,13 +576,15 @@ function isVibeCodingTerm(term) {
 }
 
 function preferredVariant(variants) {
-  return [...variants.entries()]
-    .sort((a, b) => (
-      b[1].prompt_count - a[1].prompt_count
-      || b[1].count - a[1].count
-      || a[0].length - b[0].length
-      || a[0].localeCompare(b[0])
-    ))[0]?.[0] || "";
+  return (
+    [...variants.entries()].sort(
+      (a, b) =>
+        b[1].prompt_count - a[1].prompt_count ||
+        b[1].count - a[1].count ||
+        a[0].length - b[0].length ||
+        a[0].localeCompare(b[0]),
+    )[0]?.[0] || ""
+  );
 }
 
 /** Prefer natural-language intent; drop fenced/code-heavy lines before tokenizing. */
@@ -575,8 +596,14 @@ function promptTextForCloud(text) {
     .replace(/[A-Za-z]:\\[^\s"'`]+/g, " ")
     .replace(/<[^>]*>/g, " ")
     .replace(/--[A-Za-z0-9_-]+\s*:[^;]+;?/g, " ")
-    .replace(/\b(?:import\s+\S+\s+from\s+\S+|from\s+\S+\s+import\s+\S+|(?:const|let|var)\s+\w+\s*=|(?:class|def|function)\s+\w+)[^\n]*$/gim, " ")
-    .replace(/^\s*(?:import\b|from\s+\S+\s+import\b|class\s+\w+|def\s+\w+|const\s+\w+|let\s+\w+|var\s+\w+|function\s+\w+)\b.*$/gim, " ")
+    .replace(
+      /\b(?:import\s+\S+\s+from\s+\S+|from\s+\S+\s+import\s+\S+|(?:const|let|var)\s+\w+\s*=|(?:class|def|function)\s+\w+)[^\n]*$/gim,
+      " ",
+    )
+    .replace(
+      /^\s*(?:import\b|from\s+\S+\s+import\b|class\s+\w+|def\s+\w+|const\s+\w+|let\s+\w+|var\s+\w+|function\s+\w+)\b.*$/gim,
+      " ",
+    )
     .replace(/\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b/gi, " ")
     .replace(/\b(?:torch|numpy|nn|plt|pd|np)\.[A-Za-z_][\w.]*\b/g, " ")
     .split(/\r?\n/)
@@ -586,7 +613,8 @@ function promptTextForCloud(text) {
 
 function tokenize(text) {
   const normalized = String(text || "");
-  const matches = normalized.match(/[\p{Script=Han}]+|[a-z0-9][a-z0-9_-]{1,}/giu) || [];
+  const matches =
+    normalized.match(/[\p{Script=Han}]+|[a-z0-9][a-z0-9_-]{1,}/giu) || [];
   const terms = [];
   for (const match of matches) {
     if (/^[\p{Script=Han}]+$/u.test(match)) {
@@ -595,12 +623,13 @@ function tokenize(text) {
       terms.push(...splitAsciiTerm(match));
     }
   }
-  return terms.filter((term) => (
-    term.length > 1
-    && !STOP_WORDS.has(term)
-    && !HAN_STOP_WORDS.has(term)
-    && !/^\d+$/.test(term)
-  ));
+  return terms.filter(
+    (term) =>
+      term.length > 1 &&
+      !STOP_WORDS.has(term) &&
+      !HAN_STOP_WORDS.has(term) &&
+      !/^\d+$/.test(term),
+  );
 }
 
 function splitHanTerm(term) {
@@ -637,11 +666,12 @@ function splitHanTerm(term) {
         { length: segment.segment.length },
         (_, offset) => segment.index + offset,
       ).every((index) => knownCoverage.has(index));
-      if (!overlapsKnown) matches.push({
-        term: value,
-        start: segment.index,
-        end: segment.index + segment.segment.length,
-      });
+      if (!overlapsKnown)
+        matches.push({
+          term: value,
+          start: segment.index,
+          end: segment.index + segment.segment.length,
+        });
     }
   }
 
@@ -656,10 +686,23 @@ function looksLikeCodeLine(line) {
   if (!trimmed) return false;
   const withoutDiff = trimmed.replace(/^[+-]\s?/, "");
   const hasHan = /[\p{Script=Han}]/u.test(withoutDiff);
-  if (/^(const|let|var|return|import|export|function|class|if|else|for|while|await|async)\b/.test(withoutDiff)) return true;
-  if (/\b(className|useState|useEffect|style=|aria-|data-|set[A-Z][A-Za-z0-9_]*)\b/.test(withoutDiff)) return true;
+  if (
+    /^(const|let|var|return|import|export|function|class|if|else|for|while|await|async)\b/.test(
+      withoutDiff,
+    )
+  )
+    return true;
+  if (
+    /\b(className|useState|useEffect|style=|aria-|data-|set[A-Z][A-Za-z0-9_]*)\b/.test(
+      withoutDiff,
+    )
+  )
+    return true;
   if (!hasHan && /[{}<>;=]/.test(withoutDiff)) return true;
-  const styleTokens = withoutDiff.match(/\b(?:text|bg|border|rounded|flex|grid|items|justify|gap|px|py|mt|mb|w|h|dark):?-[A-Za-z0-9/[\].%-]+/g) || [];
+  const styleTokens =
+    withoutDiff.match(
+      /\b(?:text|bg|border|rounded|flex|grid|items|justify|gap|px|py|mt|mb|w|h|dark):?-[A-Za-z0-9/[\].%-]+/g,
+    ) || [];
   if (!hasHan && styleTokens.length >= 3) return true;
   return false;
 }

--- a/src/extract/phrase-stats.js
+++ b/src/extract/phrase-stats.js
@@ -128,7 +128,6 @@ const STOP_WORDS = new Set([
   "range",
   "gemini",
   "json",
-  "judew",
   "mentioned",
   "opencode",
   "png",
@@ -576,7 +575,8 @@ function promptTextForCloud(text) {
     .replace(/[A-Za-z]:\\[^\s"'`]+/g, " ")
     .replace(/<[^>]*>/g, " ")
     .replace(/--[A-Za-z0-9_-]+\s*:[^;]+;?/g, " ")
-    .replace(/\b(?:import|from\s+\S+\s+import|class\s+\w+|def\s+\w+|const\s+\w+|let\s+\w+|var\s+\w+|function\s+\w+)\b[\s\S]*$/gim, " ")
+    .replace(/\b(?:import\s+\S+\s+from\s+\S+|from\s+\S+\s+import\s+\S+|(?:const|let|var)\s+\w+\s*=|(?:class|def|function)\s+\w+)[^\n]*$/gim, " ")
+    .replace(/^\s*(?:import\b|from\s+\S+\s+import\b|class\s+\w+|def\s+\w+|const\s+\w+|let\s+\w+|var\s+\w+|function\s+\w+)\b.*$/gim, " ")
     .replace(/\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b/gi, " ")
     .replace(/\b(?:torch|numpy|nn|plt|pd|np)\.[A-Za-z_][\w.]*\b/g, " ")
     .split(/\r?\n/)

--- a/src/extract/prompt-analysis.js
+++ b/src/extract/prompt-analysis.js
@@ -408,7 +408,7 @@ function codeLikeScore(text) {
   }
   const codeLines = (
     raw.match(
-      /^\s*(?:(?:import|from|const|let|var|def|class|function|export|return|if|for|while|try|catch)\b|[.#]?[A-Za-z_$][\w$:.\[\]#-]*\s*\{|[\w-]+\s*:\s*[^:]+;?\s*$|<\/?[A-Za-z][^>]*>)/gim,
+      /^\s*(?:(?:import|from|const|let|var|def|class|function|export|return|if|for|while|try|catch)\b|[.#]?[A-Za-z_$][\w$:.[]\]#-]*\s*\{|[\w-]+\s*:\s*[^:]+;?\s*$|<\/?[A-Za-z][^>]*>)/gim,
     ) || []
   ).length;
   if (codeLines >= 2) score += 2;

--- a/src/extract/prompt-analysis.js
+++ b/src/extract/prompt-analysis.js
@@ -36,12 +36,15 @@ function analyzePrompts(prompts, { usefulLimit = 60 } = {}) {
       categories: classification.categories,
       usefulness: classification.usefulness,
       reasons: classification.reasons,
+      artifact_origin: classification.artifact_origin,
+      artifact_kinds: classification.artifact_kinds,
     };
 
     if (classification.useful) {
+      const intentText = classification.intent_text || text;
       usefulCount += 1;
-      usefulCharacterCount += text.length;
-      if (text.length >= 600) longPromptCount += 1;
+      usefulCharacterCount += intentText.length;
+      if (intentText.length >= 600) longPromptCount += 1;
       const weight = 1 / classification.categories.length;
       for (const category of classification.categories) {
         const bucket = categories[category];
@@ -49,7 +52,7 @@ function analyzePrompts(prompts, { usefulLimit = 60 } = {}) {
         if (bucket.examples.length < 3) bucket.examples.push(preview(entry));
       }
       usefulForStats.push({
-        text: entry.text,
+        text: classification.intent_text || entry.text,
         source: entry.source,
         timestamp: entry.timestamp,
         categories: entry.categories,
@@ -80,10 +83,6 @@ function analyzePrompts(prompts, { usefulLimit = 60 } = {}) {
 }
 
 function classifyPrompt(text) {
-  const normalized = text.toLowerCase();
-  const codeScore = codeLikeScore(text);
-  const logScore = logLikeScore(text);
-
   if (isSystemOrToolNoise(text)) {
     return {
       useful: false,
@@ -91,92 +90,193 @@ function classifyPrompt(text) {
       category: "reference",
       categories: ["reference"],
       reasons: ["system_or_tool_noise"],
+      artifact_origin: "app_owned",
+      artifact_kinds: [],
+      intent_text: "",
     };
   }
 
-  if (logScore >= 3) {
+  const artifacts = artifactEvidence(text);
+  const intentText = textOutsideArtifacts(text, artifacts);
+  const origin = artifacts.kinds.length > 0 ? inferArtifactOrigin(intentText) : null;
+
+  // Large structured material has ambiguous provenance. Keep only request prose
+  // with explicit provenance or an inherently reference-shaped attachment.
+  if (artifacts.strong) {
+    if (hasSubstantialUserIntent(intentText) && canRetainArtifactIntent(artifacts, origin)) {
+      const categories = inferCategories(intentText.toLowerCase());
+      return {
+        useful: true,
+        usefulness: "high",
+        category: categories[0],
+        categories,
+        reasons: [
+          origin === "user_authored"
+            ? "user_authored_artifact_with_intent"
+            : origin === "external_or_generated"
+              ? "user_intent_with_external_reference"
+              : "user_intent_with_attached_reference",
+        ],
+        artifact_origin: origin,
+        artifact_kinds: artifacts.kinds,
+        intent_text: intentText,
+      };
+    }
     return {
       useful: false,
       usefulness: "reference",
       category: "reference",
       categories: ["reference"],
-      reasons: ["looks_like_error_or_log"],
+      reasons: [referenceReason(artifacts, origin)],
+      artifact_origin: origin,
+      artifact_kinds: artifacts.kinds,
+      intent_text: intentText,
     };
   }
 
-  // Heavy pasted files / dumps — never treat as useful intent prompts.
-  if (codeScore >= 4) {
+  if (
+    artifacts.moderate &&
+    (!hasSubstantialUserIntent(intentText) || !canRetainArtifactIntent(artifacts, origin))
+  ) {
     return {
       useful: false,
       usefulness: "reference",
       category: "reference",
       categories: ["reference"],
-      reasons: ["looks_like_pasted_code"],
+      reasons: [referenceReason(artifacts, origin)],
+      artifact_origin: origin,
+      artifact_kinds: artifacts.kinds,
+      intent_text: intentText,
     };
   }
 
-  // Milder code blocks without enough natural-language intent.
-  if (codeScore >= 3 && !hasSubstantialUserIntent(text)) {
-    return {
-      useful: false,
-      usefulness: "reference",
-      category: "reference",
-      reasons: ["looks_like_pasted_code"],
-    };
-  }
-
-  const categories = inferCategories(normalized);
+  const categoryText = artifacts.kinds.length > 0 ? (intentText || text) : text;
+  const categories = inferCategories(categoryText.toLowerCase());
   return {
     useful: true,
     usefulness: "high",
     category: categories[0],
     categories,
-    reasons: ["contains_user_intent"],
+    reasons: [
+      artifacts.kinds.length > 0
+        ? artifactIntentReason(origin)
+        : "contains_user_intent",
+    ],
+    artifact_origin: origin,
+    artifact_kinds: artifacts.kinds,
+    intent_text: categoryText,
   };
 }
 
 function isSystemOrToolNoise(text) {
   const raw = String(text || "");
   if (/<system_notification>/i.test(raw)) return true;
-  if (/^\s*<(?:system|tool_result|tool_call|agent_transcript)[\s>]/i.test(raw)) return true;
+  if (
+    /^\s*<(?:system|tool_result|tool_call|agent_transcript|recommended_plugins|environment_context|app-context|permissions|collaboration_mode|apps_instructions|plugins_instructions|skills_instructions)[\s>]/i.test(
+      raw,
+    )
+  ) {
+    return true;
+  }
+  if (/^\s*#\s*AGENTS\.md instructions\b/i.test(raw)) return true;
+  if (/^\s*<INSTRUCTIONS>[\s\S]*<\/INSTRUCTIONS>\s*$/i.test(raw)) return true;
+  if (/^\s*You are (?:ChatGPT|Codex),?\b/i.test(raw)) return true;
+  if (/Here is a list of plugins that are available but not installed/i.test(raw)) return true;
   if (/\bThe following task has finished\b/i.test(raw)) return true;
   if (/^\s*\[?(system|tool)\]?\s*:/i.test(raw)) return true;
   return false;
 }
 
-/** Intent outside fenced/code lines — avoids counting "IMPLEMENT" inside dumps. */
-function hasSubstantialUserIntent(text) {
-  const stripped = String(text || "")
-    .replace(/```[\s\S]*?```/g, " ")
-    .replace(/^\s*(import|from|const|let|var|def|class|function|export|package|#include)\b.*$/gim, " ")
+/** Keep request prose while removing common attached-material line shapes. */
+function textOutsideArtifacts(text, artifacts = artifactEvidence(text)) {
+  let stripped = String(text || "").replace(/```[\s\S]*?```/g, " ");
+  if (artifacts.kinds.includes("diff")) {
+    stripped = stripped
+      .replace(/^\s*(?:diff --git|index [a-f0-9.]+|@@ .* @@|[+-]{3} [ab]\/).*$\n?/gim, " ")
+      .replace(/^\s*[+-](?![+-]).*$\n?/gm, " ");
+  }
+  return stripped
+    .replace(
+      /^\s*Traceback \(most recent call last\):[\s\S]*?^\s*[A-Za-z]+Error:.*$\n?/gim,
+      " ",
+    )
+    .replace(
+      /^\s*(?:at .+:\d+:\d+|Traceback \(most recent call last\):|File ["'].+["'], line \d+.*|[A-Za-z]+Error:).*$\n?/gim,
+      " ",
+    )
+    .replace(/^\s*(?:[$%]\s+\S+|npm (?:ERR!|WARN)|ELIFECYCLE|Process exited with code).*$\n?/gim, " ")
+    .replace(
+      /^\s*(?:import\s+(?:["'{*]|[\w$]+\s+from\b).*|from\s+\S+\s+import\b.*|(?:const|let|var)\s+\w+\s*=.*|(?:def|class|function)\s+\w+\s*[:({].*|export\s+(?:default\b|(?:const|let|var|class|function)\b).*|package\s+[\w.]+\s*;|#include\s*[<"].*|(?:if|for|while|catch)\s*\(.*|(?:try|else)\s*\{.*)$/gim,
+      " ",
+    )
+    .replace(/^\s*(?:[A-Za-z_$][\w$]*\.)?[A-Za-z_$][\w$]*\([^)]*\)\s*;?\s*$/gm, " ")
+    .replace(/^\s*["']?[\w.-]+["']?\s*[:=]\s*(?:["'[{\d]|true\b|false\b|null\b).*$\n?/gim, " ")
     .replace(/[{};=<>]{2,}/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+/** Intent outside fenced/code lines — avoids counting "IMPLEMENT" inside dumps. */
+function hasSubstantialUserIntent(text) {
+  const stripped = String(text || "").trim();
   if (stripped.length < 12) return false;
-  return hasIntentVerb(stripped.toLowerCase()) || /[\p{Script=Han}]{2,}/u.test(stripped);
+  return hasIntentVerb(stripped.toLowerCase());
+}
+
+function inferArtifactOrigin(text) {
+  const raw = String(text || "");
+  if (
+    /(?:AI|模型|助手|工具|脚手架|模板).{0,16}(?:生成|产出|导出)|(?:复制|粘贴|摘录|引用|终端输出|运行结果|报错日志|第三方代码)|(?:generated|produced|exported) by (?:an? )?(?:AI|model|tool)|(?:copied|pasted|quoted|generated) (?:code|config|output|diff|text)|(?:terminal|command|test) output/i.test(
+      raw,
+    )
+  ) {
+    return "external_or_generated";
+  }
+  if (
+    /(?:我(?:自己|刚刚?|已经)?写的|我写了|这是我(?:自己)?(?:写|实现|整理|配置)的|下面是我(?:自己)?写的|我的(?:这段|以下)?(?:代码|配置|查询|脚本|补丁|文档|SQL)|(?:code|config|query|script|patch|spec) i (?:wrote|implemented|authored)|i (?:wrote|implemented|authored) (?:this|the) (?:code|config|query|script|patch|spec)|my (?:javascript|js|python|code|config|query|script|patch|spec))/i.test(
+      raw,
+    )
+  ) {
+    return "user_authored";
+  }
+  return "unverified";
+}
+
+function canRetainArtifactIntent(artifacts, origin) {
+  if (origin !== "unverified") return true;
+  if (artifacts.kinds.some((kind) => ["prompt_template", "opaque_text"].includes(kind))) {
+    return false;
+  }
+  return artifacts.kinds.length > 0;
+}
+
+function artifactIntentReason(origin) {
+  if (origin === "user_authored") return "user_authored_artifact_with_intent";
+  if (origin === "external_or_generated") return "user_intent_with_external_reference";
+  return "user_intent_with_attached_reference";
 }
 
 function inferCategories(text) {
   const rules = [
-    ["planning", /(方案|计划|架构|先不要写代码|brainstorm|plan|architecture)/i],
-    ["debugging", /(bug|报错|错误|失败|修复|debug|error|exception|traceback|syntaxerror)/i],
-    ["testing", /(测试|test|spec|回归|覆盖率|断言)/i],
-    ["refactor", /(重构|refactor|抽象|拆分|整理)/i],
-    ["packaging", /(打包|发布|npm|xpi|release|publish|build)/i],
-    ["explanation", /(解释|为什么|讲一下|说明|explain|why)/i],
-    ["research", /(查找|调研|搜索|资料|文档|research|search|look up)/i],
-    ["ui_design", /(页面|布局|组件|交互|视觉|按钮|ui|ux|style|css|design)/i],
-    ["workflow", /(workflow|流程|自动化|hook|mcp|skill|agent|instructions|system prompt)/i],
+    ["planning", /(?:方案|计划|架构|先不要写代码|\b(?:brainstorm|plan|architecture)\b)/i],
+    ["debugging", /(?:bug|报错|错误|失败|修复|\b(?:debug|error|exception|traceback|syntaxerror)\b)/i],
+    ["testing", /(?:测试|回归|覆盖率|断言|\b(?:test|spec)\b)/i],
+    ["refactor", /(?:重构|抽象|拆分|整理|\brefactor\b)/i],
+    ["packaging", /(?:打包|发布|\b(?:npm|xpi|release|publish|build)\b)/i],
+    ["explanation", /(?:解释|为什么|讲一下|说明|\b(?:explain|why)\b)/i],
+    ["research", /(?:查找|调研|搜索|资料|文档|\b(?:research|search|look up)\b)/i],
+    ["ui_design", /(?:页面|布局|组件|交互|视觉|按钮|\b(?:ui|ux|style|css|design)\b)/i],
+    ["workflow", /(?:流程|自动化|\b(?:workflow|hook|mcp|skill|agent|instructions|system prompt)\b)/i],
   ];
   const matched = rules.filter(([, pattern]) => pattern.test(text)).map(([name]) => name);
-  if (/(实现|编写|创建|新增|修改|开发|implement|create|add|write|code|update|build)/i.test(text)) {
+  if (/(?:实现|编写|创建|新增|修改|开发|\b(?:implement|create|add|write|code|update|build)\b)/i.test(text)) {
     matched.push("implementation");
   }
   return [...new Set(matched.length > 0 ? matched : ["implementation"])];
 }
 
 function hasIntentVerb(text) {
-  return /(帮我|请|我要|我想|实现|做|改|修|优化|设计|解释|分析|生成|add|fix|build|create|implement|explain|analyze|update|refactor)/i.test(
+  return /(?:帮我|请|我要|我想|实现|做|改|修|优化|设计|解释|分析|生成|\b(?:add|fix|build|create|implement|explain|analyze|update|refactor)\b)/i.test(
     text,
   );
 }
@@ -197,6 +297,12 @@ function codeLikeScore(text) {
     const codeTokens = (raw.match(/\b(def|class|import|return|const|self|torch|nn|plt)\b/gi) || []).length;
     if (codeTokens >= 6) score += 2;
   }
+  const codeLines = (
+    raw.match(
+      /^\s*(?:(?:import|from|const|let|var|def|class|function|export|return|if|for|while|try|catch)\b|[.#]?[A-Za-z_$][\w$:.\[\]#-]*\s*\{|[\w-]+\s*:\s*[^:]+;?\s*$|<\/?[A-Za-z][^>]*>)/gim,
+    ) || []
+  ).length;
+  if (codeLines >= 2) score += 2;
   if (/[A-Za-z0-9_$]+\([^)]*\)/.test(raw)) score += 1;
   return score;
 }
@@ -208,6 +314,114 @@ function logLikeScore(text) {
   if (/(warning|error|failed|missing resource|deprecated)/i.test(text)) score += 1;
   if (text.split(/\r?\n/).length >= 6 && /:\d+:\d+/.test(text)) score += 1;
   return score;
+}
+
+function artifactEvidence(text) {
+  const raw = String(text || "");
+  const code = codeLikeScore(raw);
+  const log = logLikeScore(raw);
+  const diff = diffLikeScore(raw);
+  const config = configLikeScore(raw);
+  const terminal = terminalLikeScore(raw);
+  const template = promptTemplateLikeScore(raw);
+  const opaque = opaqueTextLikeScore(raw);
+  const kinds = [];
+
+  if (code >= 3) kinds.push("code");
+  if (config >= 3) kinds.push("config");
+  if (diff >= 3) kinds.push("diff");
+  if (log >= 3) kinds.push("log");
+  if (terminal >= 3) kinds.push("terminal_output");
+  if (template >= 3) kinds.push("prompt_template");
+  if (opaque >= 3) kinds.push("opaque_text");
+
+  return {
+    kinds,
+    strong:
+      code >= 4 ||
+      config >= 4 ||
+      diff >= 4 ||
+      log >= 3 ||
+      terminal >= 4 ||
+      template >= 4 ||
+      opaque >= 4,
+    moderate: kinds.length > 0,
+  };
+}
+
+function diffLikeScore(text) {
+  let score = 0;
+  if (/^diff --git /m.test(text)) score += 2;
+  if (/^@@ .+ @@/m.test(text)) score += 1;
+  if (/^(?:---|\+\+\+) [ab]\//m.test(text)) score += 1;
+  if ((text.match(/^[+-](?![+\-\s]).+$/gm) || []).length >= 4) score += 2;
+  return score;
+}
+
+function configLikeScore(text) {
+  let score = 0;
+  if (/```(?:json|jsonc|ya?ml|toml|ini|env|xml)\b/i.test(text)) score += 4;
+  const trimmed = String(text || "").trim();
+  if (/^[{[]/.test(trimmed)) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed === "object") score += 4;
+    } catch {
+      // Invalid JSON continues through the structural checks below.
+    }
+  }
+  const keyValueLines = (
+    text.match(/^\s*["']?[\w.-]+["']?\s*[:=]\s*(?:["'[{\d]|true\b|false\b|null\b).+$/gim) || []
+  ).length;
+  if (keyValueLines >= 4) score += 3;
+  if (keyValueLines >= 10) score += 1;
+  return score;
+}
+
+function terminalLikeScore(text) {
+  let score = 0;
+  const promptLines = (text.match(/^\s*[$%]\s+\S.+$/gm) || []).length;
+  if (promptLines >= 1) score += 2;
+  if (promptLines >= 3) score += 1;
+  if (/(?:npm ERR!|ELIFECYCLE|Process exited with code|command not found|Tests:\s+\d+)/i.test(text)) score += 2;
+  if ((text.match(/^\s*(?:PASS|FAIL|WARN|ERROR|INFO)\b/gm) || []).length >= 3) score += 2;
+  return score;
+}
+
+function promptTemplateLikeScore(text) {
+  let score = 0;
+  if (/^\s*(?:system|developer) prompt\s*:/im.test(text)) score += 2;
+  if (/^\s*You are (?:an?|the)\b/im.test(text)) score += 2;
+  const sections = (
+    text.match(/^\s*#{1,3}\s*(?:context|instructions?|constraints?|rules?|output format|examples?|任务|指令|约束|输出格式)\s*$/gim) ||
+    []
+  ).length;
+  if (sections >= 2) score += 2;
+  if (sections >= 4) score += 2;
+  if (/\{\{[\w.-]+\}\}|<PLACEHOLDER>|\[(?:INSERT|PLACEHOLDER)[^\]]*\]/i.test(text)) score += 1;
+  return score;
+}
+
+function opaqueTextLikeScore(text) {
+  const raw = String(text || "");
+  if (/[A-Za-z0-9+/]{500,}={0,2}/.test(raw)) return 4;
+  const longestLine = raw.split(/\r?\n/).reduce((max, line) => Math.max(max, line.length), 0);
+  return longestLine >= 1500 && (raw.match(/\s/g) || []).length / Math.max(1, raw.length) < 0.08
+    ? 4
+    : 0;
+}
+
+function referenceReason(artifacts, origin) {
+  if (origin === "user_authored") return "user_authored_artifact_without_intent";
+  if (origin === "external_or_generated") return "external_reference_without_intent";
+  if (artifacts.kinds.includes("prompt_template")) return "looks_like_prompt_template";
+  if (artifacts.kinds.includes("log") || artifacts.kinds.includes("terminal_output")) {
+    return "looks_like_error_or_log";
+  }
+  if (artifacts.kinds.length === 1 && artifacts.kinds[0] === "code") {
+    return "unverified_code_origin";
+  }
+  return "unverified_artifact_origin";
 }
 
 function preview(entry) {
@@ -222,11 +436,15 @@ function summarizeReferences(referencePrompts) {
   const signals = emptyReferenceSignals();
   for (const prompt of referencePrompts) {
     addReferenceSignals(signals, prompt.text);
+    for (const kind of prompt.artifact_kinds || []) inc(signals.artifact_kinds, kind);
   }
 
   return {
     count: referencePrompts.length,
-    code_or_log_count: referencePrompts.length,
+    artifact_count: referencePrompts.filter((prompt) => prompt.artifact_kinds?.length > 0).length,
+    code_or_log_count: referencePrompts.filter((prompt) =>
+      prompt.artifact_kinds?.some((kind) => ["code", "log", "terminal_output"].includes(kind)),
+    ).length,
     signals: finalizeReferenceSignals(signals),
     examples: referencePrompts.slice(0, 5).map(preview),
   };
@@ -238,6 +456,7 @@ function emptyReferenceSignals() {
     file_extensions: new Map(),
     error_types: new Map(),
     files: new Map(),
+    artifact_kinds: new Map(),
   };
 }
 
@@ -355,6 +574,7 @@ function finalizeReferenceSignals(signals) {
     languages: mapToObject(signals.languages),
     file_extensions: mapToObject(signals.file_extensions),
     error_types: mapToObject(signals.error_types),
+    artifact_kinds: mapToObject(signals.artifact_kinds),
     files: Array.from(signals.files.values()).slice(0, 40),
   };
 }

--- a/src/extract/prompt-analysis.js
+++ b/src/extract/prompt-analysis.js
@@ -270,8 +270,9 @@ function stripTerminalBlocks(text) {
       continue;
     }
     if (
-      sawBlank &&
-      (hasIntentVerb(line.toLowerCase()) || hasQuestionIntent(line))
+      hasDirectRequestIntent(line) ||
+      hasQuestionIntent(line) ||
+      (sawBlank && hasIntentVerb(line.toLowerCase()))
     ) {
       inTerminal = false;
       sawBlank = false;
@@ -297,6 +298,13 @@ function hasQuestionIntent(text) {
     /(?:为什么|为何|怎么回事|怎么|怎样|如何|哪里|哪儿|什么问题|是否|能否|可不可以|有没有)/u.test(
       raw,
     )
+  );
+}
+
+function hasDirectRequestIntent(text) {
+  const raw = String(text || "").trim();
+  return /^(?:(?:please|kindly)\s+)?(?:add|fix|build|create|implement|explain|analyze|summarize|update|refactor|write|review)\b(?!\s+(?:available|complete|completed|failed|finished|successful|succeeded)\b)|^(?:请|帮我|麻烦|实现|修改|修复|优化|设计|解释|分析|生成)/iu.test(
+    raw,
   );
 }
 
@@ -382,7 +390,7 @@ function inferCategories(text) {
 }
 
 function hasIntentVerb(text) {
-  return /(?:帮我|请|我要|我想|实现|做|改|修|优化|设计|解释|分析|生成|\b(?:add|fix|build|create|implement|explain|analyze|summarize|update|refactor)\b)/i.test(
+  return /(?:帮我|请|我要|我想|实现|做|改|修|优化|设计|解释|分析|生成|\b(?:add|fix|build|create|implement|explain|analyze|summarize|update|refactor|write|review)\b)/i.test(
     text,
   );
 }

--- a/src/extract/prompt-analysis.js
+++ b/src/extract/prompt-analysis.js
@@ -348,7 +348,10 @@ function inferCategories(text) {
       "debugging",
       /(?:bug|报错|错误|失败|修复|\b(?:debug|error|exception|traceback|syntaxerror)\b)/i,
     ],
-    ["testing", /(?:测试|回归|覆盖率|断言|\b(?:test|spec)\b)/i],
+    [
+      "testing",
+      /(?:测试|回归|覆盖率|断言|\b(?:tests?|testing|tested|specs?)\b)/i,
+    ],
     ["refactor", /(?:重构|抽象|拆分|整理|\brefactor\b)/i],
     ["packaging", /(?:打包|发布|\b(?:npm|xpi|release|publish|build)\b)/i],
     ["explanation", /(?:解释|为什么|讲一下|说明|\b(?:explain|why)\b)/i],
@@ -379,7 +382,7 @@ function inferCategories(text) {
 }
 
 function hasIntentVerb(text) {
-  return /(?:帮我|请|我要|我想|实现|做|改|修|优化|设计|解释|分析|生成|\b(?:add|fix|build|create|implement|explain|analyze|update|refactor)\b)/i.test(
+  return /(?:帮我|请|我要|我想|实现|做|改|修|优化|设计|解释|分析|生成|\b(?:add|fix|build|create|implement|explain|analyze|summarize|update|refactor)\b)/i.test(
     text,
   );
 }
@@ -498,7 +501,7 @@ function configLikeScore(text) {
 function terminalLikeScore(text) {
   let score = 0;
   const promptLines = (text.match(/^\s*[$%]\s+\S.+$/gm) || []).length;
-  if (promptLines >= 1) score += 2;
+  if (promptLines >= 1) score += 3;
   if (promptLines >= 3) score += 1;
   if (
     /(?:npm ERR!|ELIFECYCLE|Process exited with code|command not found|Tests:\s+\d+)/i.test(

--- a/src/extract/prompt-analysis.js
+++ b/src/extract/prompt-analysis.js
@@ -60,7 +60,8 @@ function analyzePrompts(prompts, { usefulLimit = 60 } = {}) {
       if (usefulPrompts.length < usefulLimit) usefulPrompts.push(entry);
     } else {
       categories.reference.count += 1;
-      if (categories.reference.examples.length < 3) categories.reference.examples.push(preview(entry));
+      if (categories.reference.examples.length < 3)
+        categories.reference.examples.push(preview(entry));
       referencePrompts.push(entry);
     }
   }
@@ -70,7 +71,9 @@ function analyzePrompts(prompts, { usefulLimit = 60 } = {}) {
     useful_prompt_count: usefulCount,
     reference_prompt_count: referencePrompts.length,
     useful_ratio:
-      prompts && prompts.length > 0 ? Number((usefulCount / prompts.length).toFixed(4)) : 0,
+      prompts && prompts.length > 0
+        ? Number((usefulCount / prompts.length).toFixed(4))
+        : 0,
     average_useful_prompt_chars:
       usefulCount > 0 ? Math.round(usefulCharacterCount / usefulCount) : 0,
     long_prompt_ratio:
@@ -98,12 +101,16 @@ function classifyPrompt(text) {
 
   const artifacts = artifactEvidence(text);
   const intentText = textOutsideArtifacts(text, artifacts);
-  const origin = artifacts.kinds.length > 0 ? inferArtifactOrigin(intentText) : null;
+  const origin =
+    artifacts.kinds.length > 0 ? inferArtifactOrigin(intentText) : null;
 
   // Large structured material has ambiguous provenance. Keep only request prose
   // with explicit provenance or an inherently reference-shaped attachment.
   if (artifacts.strong) {
-    if (hasSubstantialUserIntent(intentText) && canRetainArtifactIntent(artifacts, origin)) {
+    if (
+      hasSubstantialUserIntent(intentText) &&
+      canRetainArtifactIntent(artifacts, origin)
+    ) {
       const categories = inferCategories(intentText.toLowerCase());
       return {
         useful: true,
@@ -136,7 +143,8 @@ function classifyPrompt(text) {
 
   if (
     artifacts.moderate &&
-    (!hasSubstantialUserIntent(intentText) || !canRetainArtifactIntent(artifacts, origin))
+    (!hasSubstantialUserIntent(intentText) ||
+      !canRetainArtifactIntent(artifacts, origin))
   ) {
     return {
       useful: false,
@@ -150,7 +158,7 @@ function classifyPrompt(text) {
     };
   }
 
-  const categoryText = artifacts.kinds.length > 0 ? (intentText || text) : text;
+  const categoryText = artifacts.kinds.length > 0 ? intentText || text : text;
   const categories = inferCategories(categoryText.toLowerCase());
   return {
     useful: true,
@@ -181,7 +189,10 @@ function isSystemOrToolNoise(text) {
   if (/^\s*#\s*AGENTS\.md instructions\b/i.test(raw)) return true;
   if (/^\s*<INSTRUCTIONS>[\s\S]*<\/INSTRUCTIONS>\s*$/i.test(raw)) return true;
   if (/^\s*You are (?:ChatGPT|Codex),?\b/i.test(raw)) return true;
-  if (/Here is a list of plugins that are available but not installed/i.test(raw)) return true;
+  if (
+    /Here is a list of plugins that are available but not installed/i.test(raw)
+  )
+    return true;
   if (/\bThe following task has finished\b/i.test(raw)) return true;
   if (/^\s*\[?(system|tool)\]?\s*:/i.test(raw)) return true;
   return false;
@@ -192,7 +203,10 @@ function textOutsideArtifacts(text, artifacts = artifactEvidence(text)) {
   let stripped = String(text || "").replace(/```[\s\S]*?```/g, " ");
   if (artifacts.kinds.includes("diff")) {
     stripped = stripped
-      .replace(/^\s*(?:diff --git|index [a-f0-9.]+|@@ .* @@|[+-]{3} [ab]\/).*$\n?/gim, " ")
+      .replace(
+        /^\s*(?:diff --git|index [a-f0-9.]+|@@ .* @@|[+-]{3} [ab]\/).*$\n?/gim,
+        " ",
+      )
       .replace(/^\s*[+-](?![+-]).*$\n?/gm, " ");
   }
   if (artifacts.kinds.includes("terminal_output")) {
@@ -207,13 +221,22 @@ function textOutsideArtifacts(text, artifacts = artifactEvidence(text)) {
       /^\s*(?:at .+:\d+:\d+|Traceback \(most recent call last\):|File ["'].+["'], line \d+.*|[A-Za-z]+Error:).*$\n?/gim,
       " ",
     )
-    .replace(/^\s*(?:[$%]\s+\S+|npm (?:ERR!|WARN)|ELIFECYCLE|Process exited with code).*$\n?/gim, " ")
+    .replace(
+      /^\s*(?:[$%]\s+\S+|npm (?:ERR!|WARN)|ELIFECYCLE|Process exited with code).*$\n?/gim,
+      " ",
+    )
     .replace(
       /^\s*(?:import\s+(?:["'{*]|[\w$]+\s+from\b).*|from\s+\S+\s+import\b.*|(?:const|let|var)\s+\w+\s*=.*|(?:def|class|(?:async\s+)?function)\s+\w+\s*[:({].*|export\s+(?:default\b|(?:const|let|var|class|function)\b).*|package\s+[\w.]+\s*;|#include\s*[<"].*|(?:if|for|while|catch)\s*\(.*|(?:try|else)\s*\{.*|return\s+(?:(?:await|new)\s+)?(?:[A-Za-z_$][\w$]*(?:[.(]|\s*=>)|["'[{\d]|true\b|false\b|null\b).*|throw\s+new\s+\w+\s*\(.*|[}\])]+\s*;?)$/gim,
       " ",
     )
-    .replace(/^\s*(?:[A-Za-z_$][\w$]*\.)?[A-Za-z_$][\w$]*\([^)]*\)\s*;?\s*$/gm, " ")
-    .replace(/^\s*["']?[\w.-]+["']?\s*[:=]\s*(?:["'[{\d]|true\b|false\b|null\b).*$\n?/gim, " ")
+    .replace(
+      /^\s*(?:[A-Za-z_$][\w$]*\.)?[A-Za-z_$][\w$]*\([^)]*\)\s*;?\s*$/gm,
+      " ",
+    )
+    .replace(
+      /^\s*["']?[\w.-]+["']?\s*[:=]\s*(?:["'[{\d]|true\b|false\b|null\b).*$\n?/gim,
+      " ",
+    )
     .replace(/[{};=<>]{2,}/g, " ")
     .replace(/\s+/g, " ")
     .trim();
@@ -246,7 +269,10 @@ function stripTerminalBlocks(text) {
       sawBlank = true;
       continue;
     }
-    if (sawBlank && (hasIntentVerb(line.toLowerCase()) || hasQuestionIntent(line))) {
+    if (
+      sawBlank &&
+      (hasIntentVerb(line.toLowerCase()) || hasQuestionIntent(line))
+    ) {
       inTerminal = false;
       sawBlank = false;
       kept.push(line);
@@ -265,8 +291,12 @@ function hasQuestionIntent(text) {
   const raw = String(text || "").trim();
   return (
     /[?？]/u.test(raw) ||
-    /^\s*(?:why|how|what|where|when|which|who|can|could|would|should|does|do|did|is|are)\b/i.test(raw) ||
-    /(?:为什么|为何|怎么回事|怎么|怎样|如何|哪里|哪儿|什么问题|是否|能否|可不可以|有没有)/u.test(raw)
+    /^\s*(?:why|how|what|where|when|which|who|can|could|would|should|does|do|did|is|are)\b/i.test(
+      raw,
+    ) ||
+    /(?:为什么|为何|怎么回事|怎么|怎样|如何|哪里|哪儿|什么问题|是否|能否|可不可以|有没有)/u.test(
+      raw,
+    )
   );
 }
 
@@ -291,7 +321,11 @@ function inferArtifactOrigin(text) {
 
 function canRetainArtifactIntent(artifacts, origin) {
   if (origin !== "unverified") return true;
-  if (artifacts.kinds.some((kind) => ["prompt_template", "opaque_text"].includes(kind))) {
+  if (
+    artifacts.kinds.some((kind) =>
+      ["prompt_template", "opaque_text"].includes(kind),
+    )
+  ) {
     return false;
   }
   return artifacts.kinds.length > 0;
@@ -299,24 +333,46 @@ function canRetainArtifactIntent(artifacts, origin) {
 
 function artifactIntentReason(origin) {
   if (origin === "user_authored") return "user_authored_artifact_with_intent";
-  if (origin === "external_or_generated") return "user_intent_with_external_reference";
+  if (origin === "external_or_generated")
+    return "user_intent_with_external_reference";
   return "user_intent_with_attached_reference";
 }
 
 function inferCategories(text) {
   const rules = [
-    ["planning", /(?:方案|计划|架构|先不要写代码|\b(?:brainstorm|plan|architecture)\b)/i],
-    ["debugging", /(?:bug|报错|错误|失败|修复|\b(?:debug|error|exception|traceback|syntaxerror)\b)/i],
+    [
+      "planning",
+      /(?:方案|计划|架构|先不要写代码|\b(?:brainstorm|plan|architecture)\b)/i,
+    ],
+    [
+      "debugging",
+      /(?:bug|报错|错误|失败|修复|\b(?:debug|error|exception|traceback|syntaxerror)\b)/i,
+    ],
     ["testing", /(?:测试|回归|覆盖率|断言|\b(?:test|spec)\b)/i],
     ["refactor", /(?:重构|抽象|拆分|整理|\brefactor\b)/i],
     ["packaging", /(?:打包|发布|\b(?:npm|xpi|release|publish|build)\b)/i],
     ["explanation", /(?:解释|为什么|讲一下|说明|\b(?:explain|why)\b)/i],
-    ["research", /(?:查找|调研|搜索|资料|文档|\b(?:research|search|look up)\b)/i],
-    ["ui_design", /(?:页面|布局|组件|交互|视觉|按钮|\b(?:ui|ux|style|css|design)\b)/i],
-    ["workflow", /(?:流程|自动化|\b(?:workflow|hook|mcp|skill|agent|instructions|system prompt)\b)/i],
+    [
+      "research",
+      /(?:查找|调研|搜索|资料|文档|\b(?:research|search|look up)\b)/i,
+    ],
+    [
+      "ui_design",
+      /(?:页面|布局|组件|交互|视觉|按钮|\b(?:ui|ux|style|css|design)\b)/i,
+    ],
+    [
+      "workflow",
+      /(?:流程|自动化|\b(?:workflow|hook|mcp|skill|agent|instructions|system prompt)\b)/i,
+    ],
   ];
-  const matched = rules.filter(([, pattern]) => pattern.test(text)).map(([name]) => name);
-  if (/(?:实现|编写|创建|新增|修改|开发|\b(?:implement|create|add|write|code|update|build)\b)/i.test(text)) {
+  const matched = rules
+    .filter(([, pattern]) => pattern.test(text))
+    .map(([name]) => name);
+  if (
+    /(?:实现|编写|创建|新增|修改|开发|\b(?:implement|create|add|write|code|update|build)\b)/i.test(
+      text,
+    )
+  ) {
     matched.push("implementation");
   }
   return [...new Set(matched.length > 0 ? matched : ["implementation"])];
@@ -332,7 +388,11 @@ function codeLikeScore(text) {
   let score = 0;
   const raw = String(text || "");
   if (/```/.test(raw)) score += 2;
-  if (/\b(const|let|var|function|class|return|import|export|async|await|def|self\.|torch\.|nn\.)\b/.test(raw)) {
+  if (
+    /\b(const|let|var|function|class|return|import|export|async|await|def|self\.|torch\.|nn\.)\b/.test(
+      raw,
+    )
+  ) {
     score += 1;
   }
   if (/[{};]{2,}/.test(raw)) score += 1;
@@ -341,7 +401,9 @@ function codeLikeScore(text) {
   if (lines.length >= 8) score += 1;
   // Collapsed single-line dumps still look like code by density.
   if (lines.length < 8 && raw.length > 400) {
-    const codeTokens = (raw.match(/\b(def|class|import|return|const|self|torch|nn|plt)\b/gi) || []).length;
+    const codeTokens = (
+      raw.match(/\b(def|class|import|return|const|self|torch|nn|plt)\b/gi) || []
+    ).length;
     if (codeTokens >= 6) score += 2;
   }
   const codeLines = (
@@ -356,9 +418,15 @@ function codeLikeScore(text) {
 
 function logLikeScore(text) {
   let score = 0;
-  if (/(syntaxerror|typeerror|referenceerror|traceback|exception|stack trace)/i.test(text)) score += 2;
+  if (
+    /(syntaxerror|typeerror|referenceerror|traceback|exception|stack trace)/i.test(
+      text,
+    )
+  )
+    score += 2;
   if (/\bat .+:\d+:\d+/.test(text)) score += 1;
-  if (/(warning|error|failed|missing resource|deprecated)/i.test(text)) score += 1;
+  if (/(warning|error|failed|missing resource|deprecated)/i.test(text))
+    score += 1;
   if (text.split(/\r?\n/).length >= 6 && /:\d+:\d+/.test(text)) score += 1;
   return score;
 }
@@ -418,7 +486,9 @@ function configLikeScore(text) {
     }
   }
   const keyValueLines = (
-    text.match(/^\s*["']?[\w.-]+["']?\s*[:=]\s*(?:["'[{\d]|true\b|false\b|null\b).+$/gim) || []
+    text.match(
+      /^\s*["']?[\w.-]+["']?\s*[:=]\s*(?:["'[{\d]|true\b|false\b|null\b).+$/gim,
+    ) || []
   ).length;
   if (keyValueLines >= 4) score += 3;
   if (keyValueLines >= 10) score += 1;
@@ -430,8 +500,14 @@ function terminalLikeScore(text) {
   const promptLines = (text.match(/^\s*[$%]\s+\S.+$/gm) || []).length;
   if (promptLines >= 1) score += 2;
   if (promptLines >= 3) score += 1;
-  if (/(?:npm ERR!|ELIFECYCLE|Process exited with code|command not found|Tests:\s+\d+)/i.test(text)) score += 2;
-  if ((text.match(/^\s*(?:PASS|FAIL|WARN|ERROR|INFO)\b/gm) || []).length >= 3) score += 2;
+  if (
+    /(?:npm ERR!|ELIFECYCLE|Process exited with code|command not found|Tests:\s+\d+)/i.test(
+      text,
+    )
+  )
+    score += 2;
+  if ((text.match(/^\s*(?:PASS|FAIL|WARN|ERROR|INFO)\b/gm) || []).length >= 3)
+    score += 2;
   return score;
 }
 
@@ -440,29 +516,42 @@ function promptTemplateLikeScore(text) {
   if (/^\s*(?:system|developer) prompt\s*:/im.test(text)) score += 2;
   if (/^\s*You are (?:an?|the)\b/im.test(text)) score += 2;
   const sections = (
-    text.match(/^\s*#{1,3}\s*(?:context|instructions?|constraints?|rules?|output format|examples?|任务|指令|约束|输出格式)\s*$/gim) ||
-    []
+    text.match(
+      /^\s*#{1,3}\s*(?:context|instructions?|constraints?|rules?|output format|examples?|任务|指令|约束|输出格式)\s*$/gim,
+    ) || []
   ).length;
   if (sections >= 2) score += 2;
   if (sections >= 4) score += 2;
-  if (/\{\{[\w.-]+\}\}|<PLACEHOLDER>|\[(?:INSERT|PLACEHOLDER)[^\]]*\]/i.test(text)) score += 1;
+  if (
+    /\{\{[\w.-]+\}\}|<PLACEHOLDER>|\[(?:INSERT|PLACEHOLDER)[^\]]*\]/i.test(text)
+  )
+    score += 1;
   return score;
 }
 
 function opaqueTextLikeScore(text) {
   const raw = String(text || "");
   if (/[A-Za-z0-9+/]{500,}={0,2}/.test(raw)) return 4;
-  const longestLine = raw.split(/\r?\n/).reduce((max, line) => Math.max(max, line.length), 0);
-  return longestLine >= 1500 && (raw.match(/\s/g) || []).length / Math.max(1, raw.length) < 0.08
+  const longestLine = raw
+    .split(/\r?\n/)
+    .reduce((max, line) => Math.max(max, line.length), 0);
+  return longestLine >= 1500 &&
+    (raw.match(/\s/g) || []).length / Math.max(1, raw.length) < 0.08
     ? 4
     : 0;
 }
 
 function referenceReason(artifacts, origin) {
-  if (origin === "user_authored") return "user_authored_artifact_without_intent";
-  if (origin === "external_or_generated") return "external_reference_without_intent";
-  if (artifacts.kinds.includes("prompt_template")) return "looks_like_prompt_template";
-  if (artifacts.kinds.includes("log") || artifacts.kinds.includes("terminal_output")) {
+  if (origin === "user_authored")
+    return "user_authored_artifact_without_intent";
+  if (origin === "external_or_generated")
+    return "external_reference_without_intent";
+  if (artifacts.kinds.includes("prompt_template"))
+    return "looks_like_prompt_template";
+  if (
+    artifacts.kinds.includes("log") ||
+    artifacts.kinds.includes("terminal_output")
+  ) {
     return "looks_like_error_or_log";
   }
   if (artifacts.kinds.length === 1 && artifacts.kinds[0] === "code") {
@@ -483,14 +572,19 @@ function summarizeReferences(referencePrompts) {
   const signals = emptyReferenceSignals();
   for (const prompt of referencePrompts) {
     addReferenceSignals(signals, prompt.text);
-    for (const kind of prompt.artifact_kinds || []) inc(signals.artifact_kinds, kind);
+    for (const kind of prompt.artifact_kinds || [])
+      inc(signals.artifact_kinds, kind);
   }
 
   return {
     count: referencePrompts.length,
-    artifact_count: referencePrompts.filter((prompt) => prompt.artifact_kinds?.length > 0).length,
+    artifact_count: referencePrompts.filter(
+      (prompt) => prompt.artifact_kinds?.length > 0,
+    ).length,
     code_or_log_count: referencePrompts.filter((prompt) =>
-      prompt.artifact_kinds?.some((kind) => ["code", "log", "terminal_output"].includes(kind)),
+      prompt.artifact_kinds?.some((kind) =>
+        ["code", "log", "terminal_output"].includes(kind),
+      ),
     ).length,
     signals: finalizeReferenceSignals(signals),
     examples: referencePrompts.slice(0, 5).map(preview),
@@ -628,7 +722,9 @@ function finalizeReferenceSignals(signals) {
 
 function mapToObject(map) {
   return Object.fromEntries(
-    Array.from(map.entries()).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])),
+    Array.from(map.entries()).sort(
+      (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+    ),
   );
 }
 

--- a/src/extract/prompt-analysis.js
+++ b/src/extract/prompt-analysis.js
@@ -195,6 +195,9 @@ function textOutsideArtifacts(text, artifacts = artifactEvidence(text)) {
       .replace(/^\s*(?:diff --git|index [a-f0-9.]+|@@ .* @@|[+-]{3} [ab]\/).*$\n?/gim, " ")
       .replace(/^\s*[+-](?![+-]).*$\n?/gm, " ");
   }
+  if (artifacts.kinds.includes("terminal_output")) {
+    stripped = stripTerminalBlocks(stripped);
+  }
   return stripped
     .replace(
       /^\s*Traceback \(most recent call last\):[\s\S]*?^\s*[A-Za-z]+Error:.*$\n?/gim,
@@ -206,7 +209,7 @@ function textOutsideArtifacts(text, artifacts = artifactEvidence(text)) {
     )
     .replace(/^\s*(?:[$%]\s+\S+|npm (?:ERR!|WARN)|ELIFECYCLE|Process exited with code).*$\n?/gim, " ")
     .replace(
-      /^\s*(?:import\s+(?:["'{*]|[\w$]+\s+from\b).*|from\s+\S+\s+import\b.*|(?:const|let|var)\s+\w+\s*=.*|(?:def|class|function)\s+\w+\s*[:({].*|export\s+(?:default\b|(?:const|let|var|class|function)\b).*|package\s+[\w.]+\s*;|#include\s*[<"].*|(?:if|for|while|catch)\s*\(.*|(?:try|else)\s*\{.*)$/gim,
+      /^\s*(?:import\s+(?:["'{*]|[\w$]+\s+from\b).*|from\s+\S+\s+import\b.*|(?:const|let|var)\s+\w+\s*=.*|(?:def|class|(?:async\s+)?function)\s+\w+\s*[:({].*|export\s+(?:default\b|(?:const|let|var|class|function)\b).*|package\s+[\w.]+\s*;|#include\s*[<"].*|(?:if|for|while|catch)\s*\(.*|(?:try|else)\s*\{.*|return\s+(?:(?:await|new)\s+)?(?:[A-Za-z_$][\w$]*(?:[.(]|\s*=>)|["'[{\d]|true\b|false\b|null\b).*|throw\s+new\s+\w+\s*\(.*|[}\])]+\s*;?)$/gim,
       " ",
     )
     .replace(/^\s*(?:[A-Za-z_$][\w$]*\.)?[A-Za-z_$][\w$]*\([^)]*\)\s*;?\s*$/gm, " ")
@@ -219,8 +222,52 @@ function textOutsideArtifacts(text, artifacts = artifactEvidence(text)) {
 /** Intent outside fenced/code lines — avoids counting "IMPLEMENT" inside dumps. */
 function hasSubstantialUserIntent(text) {
   const stripped = String(text || "").trim();
+  if (hasQuestionIntent(stripped)) return true;
   if (stripped.length < 12) return false;
   return hasIntentVerb(stripped.toLowerCase());
+}
+
+function stripTerminalBlocks(text) {
+  const kept = [];
+  let inTerminal = false;
+  let sawBlank = false;
+
+  for (const line of String(text || "").split(/\r?\n/)) {
+    if (/^\s*[$%]\s+\S/.test(line)) {
+      inTerminal = true;
+      sawBlank = false;
+      continue;
+    }
+    if (!inTerminal) {
+      kept.push(line);
+      continue;
+    }
+    if (!line.trim()) {
+      sawBlank = true;
+      continue;
+    }
+    if (sawBlank && (hasIntentVerb(line.toLowerCase()) || hasQuestionIntent(line))) {
+      inTerminal = false;
+      sawBlank = false;
+      kept.push(line);
+      continue;
+    }
+    sawBlank = false;
+    if (/^\s*(?:ELIFECYCLE|Process exited with code)\b/i.test(line)) {
+      inTerminal = false;
+    }
+  }
+
+  return kept.join("\n");
+}
+
+function hasQuestionIntent(text) {
+  const raw = String(text || "").trim();
+  return (
+    /[?？]/u.test(raw) ||
+    /^\s*(?:why|how|what|where|when|which|who|can|could|would|should|does|do|did|is|are)\b/i.test(raw) ||
+    /(?:为什么|为何|怎么回事|怎么|怎样|如何|哪里|哪儿|什么问题|是否|能否|可不可以|有没有)/u.test(raw)
+  );
 }
 
 function inferArtifactOrigin(text) {

--- a/src/sources/codex.js
+++ b/src/sources/codex.js
@@ -6,7 +6,12 @@ const { isInRange } = require("../lib/dates");
 const { normalizeWhitespace, textFromContent } = require("../extract/text");
 
 async function inspectCodex({ root, range } = {}) {
-  const sessionsRoot = root || path.join(process.env.CODEX_HOME || path.join(os.homedir(), ".codex"), "sessions");
+  const sessionsRoot =
+    root ||
+    path.join(
+      process.env.CODEX_HOME || path.join(os.homedir(), ".codex"),
+      "sessions",
+    );
   const files = await walkFiles(
     sessionsRoot,
     (_filePath, name) => name.startsWith("rollout-") && name.endsWith(".jsonl"),
@@ -44,7 +49,8 @@ async function inspectCodex({ root, range } = {}) {
       if (usage) {
         const delta = codexUsageDelta(usage, previousTotals);
         if (usage.total) previousTotals = usage.total;
-        if (inRequestedRange) addCodexContext(contextByDay, timestamp, delta, pendingTools);
+        if (inRequestedRange)
+          addCodexContext(contextByDay, timestamp, delta, pendingTools);
         pendingTools = [];
       }
     });
@@ -56,14 +62,17 @@ async function inspectCodex({ root, range } = {}) {
     files_scanned: files.length,
     prompt_count: prompts.length,
     token_totals: tokenTotals,
-    context_breakdown_daily: [...contextByDay.values()].sort((a, b) => a.day.localeCompare(b.day)),
+    context_breakdown_daily: [...contextByDay.values()].sort((a, b) =>
+      a.day.localeCompare(b.day),
+    ),
     prompts,
   };
 }
 
 function extractCodexPrompt(obj) {
   const payload = obj?.payload || {};
-  const nested = payload.msg && typeof payload.msg === "object" ? payload.msg : null;
+  const nested =
+    payload.msg && typeof payload.msg === "object" ? payload.msg : null;
   const type = String(payload.type || nested?.type || "").toLowerCase();
   // Codex rollouts mix user / agent / tool / token events — only keep user prompts.
   if (type !== "user_message") return "";
@@ -79,7 +88,9 @@ function extractCodexPrompt(obj) {
     nested?.content,
   ];
   for (const candidate of candidates) {
-    const text = normalizeWhitespace(stripCodexInjectedContext(textFromContent(candidate)));
+    const text = normalizeWhitespace(
+      stripCodexInjectedContext(textFromContent(candidate)),
+    );
     if (text) return text;
   }
   return "";
@@ -126,9 +137,11 @@ function stripCodexInjectedContext(value) {
 function extractCodexTokens(obj) {
   const payload = obj?.payload || {};
   const info =
-    payload.type === "token_count" ? payload.info
-    : payload.msg?.type === "token_count" ? payload.msg.info
-    : null;
+    payload.type === "token_count"
+      ? payload.info
+      : payload.msg?.type === "token_count"
+        ? payload.msg.info
+        : null;
   if (!info) return null;
   return normalizeTotals(info.total_token_usage || info);
 }
@@ -136,24 +149,32 @@ function extractCodexTokens(obj) {
 function extractCodexUsageEvent(obj) {
   const payload = obj?.payload || {};
   const info =
-    payload.type === "token_count" ? payload.info
-    : payload.msg?.type === "token_count" ? payload.msg.info
-    : null;
+    payload.type === "token_count"
+      ? payload.info
+      : payload.msg?.type === "token_count"
+        ? payload.msg.info
+        : null;
   if (!info) return null;
   return {
-    last: info.last_token_usage && typeof info.last_token_usage === "object"
-      ? info.last_token_usage
-      : null,
-    total: info.total_token_usage && typeof info.total_token_usage === "object"
-      ? info.total_token_usage
-      : null,
+    last:
+      info.last_token_usage && typeof info.last_token_usage === "object"
+        ? info.last_token_usage
+        : null,
+    total:
+      info.total_token_usage && typeof info.total_token_usage === "object"
+        ? info.total_token_usage
+        : null,
   };
 }
 
 function extractCodexTool(obj) {
-  if (obj?.type !== "response_item" || obj?.payload?.type !== "function_call") return "";
+  if (obj?.type !== "response_item" || obj?.payload?.type !== "function_call")
+    return "";
   const payload = obj.payload;
-  if (typeof payload.namespace === "string" && payload.namespace.startsWith("mcp__")) {
+  if (
+    typeof payload.namespace === "string" &&
+    payload.namespace.startsWith("mcp__")
+  ) {
     return `${payload.namespace}${payload.name || ""}`;
   }
   return typeof payload.name === "string" ? payload.name : "";
@@ -166,7 +187,10 @@ function codexUsageDelta(usage, previousTotals) {
     const previous = normalizeCodexUsage(previousTotals);
     if (total.total_tokens >= previous.total_tokens) {
       return Object.fromEntries(
-        Object.keys(total).map((key) => [key, Math.max(0, total[key] - previous[key])]),
+        Object.keys(total).map((key) => [
+          key,
+          Math.max(0, total[key] - previous[key]),
+        ]),
       );
     }
   }
@@ -176,7 +200,10 @@ function codexUsageDelta(usage, previousTotals) {
 function normalizeCodexUsage(raw) {
   const totals = normalizeTotals(raw);
   // Codex reports input inclusive of cache reads.
-  totals.input_tokens = Math.max(0, totals.input_tokens - totals.cached_input_tokens);
+  totals.input_tokens = Math.max(
+    0,
+    totals.input_tokens - totals.cached_input_tokens,
+  );
   totals.total_tokens =
     totals.input_tokens +
     totals.cached_input_tokens +
@@ -192,15 +219,19 @@ function addCodexContext(byDay, timestamp, delta, tools) {
   const row = byDay.get(day) || emptyContextRow(day, "turn_delta");
   const uniqueTools = [...new Set((tools || []).filter(Boolean))];
   const toolShare = uniqueTools.length > 0 ? 1 : 0;
-  const reasoning = Math.min(delta.total_tokens, number(delta.reasoning_output_tokens));
+  const reasoning = Math.min(
+    delta.total_tokens,
+    number(delta.reasoning_output_tokens),
+  );
   const attributable = Math.max(0, delta.total_tokens - reasoning);
   row.categories.reasoning += reasoning;
   row.categories.tool_calls += attributable * toolShare;
   row.categories.messages += attributable * (1 - toolShare);
   row.total_tokens += delta.total_tokens;
-  row.input_tokens += number(delta.input_tokens)
-    + number(delta.cached_input_tokens)
-    + number(delta.cache_creation_input_tokens);
+  row.input_tokens +=
+    number(delta.input_tokens) +
+    number(delta.cached_input_tokens) +
+    number(delta.cache_creation_input_tokens);
   row.cached_input_tokens += number(delta.cached_input_tokens);
   row.tool_call_count += uniqueTools.length;
   row.event_count += 1;

--- a/src/sources/codex.js
+++ b/src/sources/codex.js
@@ -9,7 +9,7 @@ async function inspectCodex({ root, range } = {}) {
   const sessionsRoot = root || path.join(process.env.CODEX_HOME || path.join(os.homedir(), ".codex"), "sessions");
   const files = await walkFiles(
     sessionsRoot,
-    (_filePath, name) => name.endsWith(".jsonl") && (name.startsWith("rollout-") || true),
+    (_filePath, name) => name.startsWith("rollout-") && name.endsWith(".jsonl"),
   );
   const prompts = [];
   const tokenTotals = emptyTotals();
@@ -105,11 +105,21 @@ function stripCodexInjectedContext(value) {
     "in-app-browser-context",
     "recommended_plugins",
     "environment_context",
+    "app-context",
+    "permissions",
+    "collaboration_mode",
+    "apps_instructions",
+    "plugins_instructions",
+    "skills_instructions",
   ];
   for (const tag of injectedTags) {
     const block = new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi");
     text = text.replace(block, " ");
   }
+  text = text.replace(
+    /^\s*#\s*AGENTS\.md instructions\s*<INSTRUCTIONS>[\s\S]*?<\/INSTRUCTIONS>\s*/gim,
+    " ",
+  );
   return text.trim();
 }
 

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -756,6 +756,65 @@ test("analyzePrompts retains debugging intent around an unlabelled traceback", (
   assert.equal(analysis.useful_for_stats[0].text, intent);
 });
 
+test("analyzePrompts retains interrogative intent around attached code", () => {
+  const code = [
+    "```js",
+    "export async function load() {",
+    "  const result = await fetch('/api');",
+    "  return result.json();",
+    "}",
+    "```",
+  ].join("\n");
+  const analysis = analyzePrompts([
+    { text: `Why does this fail?\n${code}` },
+    { text: `这个报错是怎么回事？\n${code}` },
+  ]);
+
+  assert.equal(analysis.useful_prompt_count, 2);
+  assert.deepEqual(
+    analysis.useful_for_stats.map((prompt) => prompt.text),
+    ["Why does this fail?", "这个报错是怎么回事？"],
+  );
+});
+
+test("analyzePrompts removes ordinary stdout from terminal attachments", () => {
+  const intent = "Please fix the failing test.";
+  const analysis = analyzePrompts([
+    {
+      text: [
+        intent,
+        "$ npm test",
+        "Loading Acme Payments Production Fixtures",
+        "Connected Banana Orchard Customer Alpha",
+        "npm ERR! Test failed",
+        "Process exited with code 1",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.equal(analysis.useful_for_stats[0].text, intent);
+  assert.ok(!wordFrequencies(analysis.useful_for_stats).some((row) => row.term === "acme"));
+});
+
+test("analyzePrompts removes unfenced code before category inference", () => {
+  const intent = "Please explain this behavior.";
+  const analysis = analyzePrompts([
+    {
+      text: [
+        intent,
+        "async function load() {",
+        "  const result = await fetchData();",
+        "  if (!result.ok) throw new Error('bad');",
+        "  return build(result);",
+        "}",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.equal(analysis.useful_for_stats[0].text, intent);
+  assert.deepEqual(analysis.useful_prompts[0].categories, ["explanation"]);
+});
+
 test("English category and intent keywords require word boundaries", () => {
   const prose = analyzePrompts([
     { text: "Please explain a guide about padding and prefixes." },

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -6,8 +6,13 @@ const os = require("node:os");
 const path = require("node:path");
 
 const { inspectSources } = require("../src/inspect");
-const { analyzePrompts } = require("../src/extract/prompt-analysis");
-const { tokenize, wordCloudRecords, wordFrequencies } = require("../src/extract/phrase-stats");
+const { analyzePrompts, classifyPrompt } = require("../src/extract/prompt-analysis");
+const {
+  tokenize,
+  wordCloudRecords,
+  wordFrequencies,
+  promptTextForCloud,
+} = require("../src/extract/phrase-stats");
 const { inspectEnvironment } = require("../src/extract/environment");
 const { dayBounds } = require("../src/lib/dates");
 const { extractCodexPrompt } = require("../src/sources/codex");
@@ -613,6 +618,333 @@ test("analyzePrompts separates useful intent from pasted code and logs", () => {
   assert.equal(analysis.categories.testing.count, 0.5);
   assert.equal(analysis.categories.planning.count, 1);
   assert.ok(analysis.useful_prompts.some((p) => p.text.includes("回归测试")));
+});
+
+test("analyzePrompts separates code authorship from surrounding request intent", () => {
+  const authored = [
+    "这是我自己写的 JavaScript，请帮我修复点击后重复提交的问题。",
+    "```js",
+    "export async function submit(form) {",
+    "  const payload = new FormData(form);",
+    "  const response = await fetch('/api/orders', { method: 'POST', body: payload });",
+    "  if (!response.ok) throw new Error('submit failed');",
+    "  return response.json();",
+    "}",
+    "```",
+  ].join("\n");
+  const unverified = authored.replace(
+    "这是我自己写的 JavaScript，请帮我修复点击后重复提交的问题。",
+    "请分析下面的 JavaScript。",
+  );
+
+  const analysis = analyzePrompts([
+    { source: "codex", text: authored },
+    { source: "codex", text: unverified },
+  ]);
+
+  assert.equal(analysis.useful_prompt_count, 2);
+  assert.equal(analysis.reference_prompt_count, 0);
+  assert.deepEqual(analysis.useful_prompts[0].reasons, ["user_authored_artifact_with_intent"]);
+  assert.equal(analysis.useful_prompts[0].artifact_origin, "user_authored");
+  assert.deepEqual(analysis.useful_prompts[0].artifact_kinds, ["code"]);
+  assert.equal(analysis.useful_prompts[0].category, "debugging");
+  assert.deepEqual(analysis.useful_prompts[1].reasons, ["user_intent_with_attached_reference"]);
+  assert.equal(analysis.useful_prompts[1].artifact_origin, "unverified");
+  assert.equal(analysis.useful_for_stats[1].text, "请分析下面的 JavaScript。");
+});
+
+test("analyzePrompts rejects app-owned prompt envelopes even when they contain JavaScript and intent verbs", () => {
+  const analysis = analyzePrompts([
+    {
+      source: "codex",
+      text: [
+        "<recommended_plugins>",
+        "Here is a list of plugins that are available but not installed.",
+        "</recommended_plugins>",
+        "# AGENTS.md instructions",
+        "<INSTRUCTIONS>Please build the feature.</INSTRUCTIONS>",
+        "```js",
+        "const build = () => test();",
+        "```",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.equal(analysis.useful_prompt_count, 0);
+  assert.equal(analysis.reference_prompt_count, 1);
+  assert.deepEqual(analysis.reference_summary.examples[0].text.startsWith("<recommended_plugins>"), true);
+});
+
+test("analyzePrompts infers categories from request text instead of JavaScript identifiers", () => {
+  const analysis = analyzePrompts([
+    {
+      source: "codex",
+      text: [
+        "这是我写的代码，请解释为什么这里会变慢。",
+        "```js",
+        "const buildTestPlan = async () => createPackage(await researchWorkflow());",
+        "export default buildTestPlan;",
+        "```",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(analysis.useful_prompts[0].categories, ["explanation"]);
+});
+
+test("analyzePrompts separates intent from generated code and terminal output", () => {
+  const generatedIntent = "这是模型生成的 Python，请帮我检查安全问题。";
+  const terminalIntent = "这是终端输出，请帮我修复构建失败。";
+  const analysis = analyzePrompts([
+    {
+      source: "codex",
+      text: [
+        generatedIntent,
+        "```python",
+        "import os",
+        "def run(value):",
+        "    return os.system(value)",
+        "```",
+      ].join("\n"),
+    },
+    {
+      source: "claude",
+      text: [
+        terminalIntent,
+        "$ npm test",
+        "npm ERR! Test failed",
+        "Process exited with code 1",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.equal(analysis.useful_prompt_count, 2);
+  assert.deepEqual(
+    analysis.useful_prompts.map((prompt) => prompt.artifact_origin),
+    ["external_or_generated", "external_or_generated"],
+  );
+  assert.deepEqual(
+    analysis.useful_prompts.map((prompt) => prompt.reasons[0]),
+    ["user_intent_with_external_reference", "user_intent_with_external_reference"],
+  );
+  assert.deepEqual(
+    analysis.useful_for_stats.map((prompt) => prompt.text),
+    [generatedIntent, terminalIntent],
+  );
+  assert.equal(analysis.average_useful_prompt_chars, Math.round((generatedIntent.length + terminalIntent.length) / 2));
+  assert.equal(analysis.long_prompt_ratio, 0);
+});
+
+test("analyzePrompts retains debugging intent around an unlabelled traceback", () => {
+  const intent = "请帮我分析这个错误并修复登录问题。";
+  const analysis = analyzePrompts([
+    {
+      text: [
+        intent,
+        "Traceback (most recent call last):",
+        '  File "auth.py", line 42, in login',
+        "    return session.user.id",
+        "AttributeError: 'NoneType' object has no attribute 'user'",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.equal(analysis.useful_prompt_count, 1);
+  assert.deepEqual(analysis.useful_prompts[0].categories, ["debugging"]);
+  assert.equal(analysis.useful_prompts[0].artifact_origin, "unverified");
+  assert.deepEqual(analysis.useful_prompts[0].reasons, ["user_intent_with_attached_reference"]);
+  assert.equal(analysis.useful_for_stats[0].text, intent);
+});
+
+test("English category and intent keywords require word boundaries", () => {
+  const prose = analyzePrompts([
+    { text: "Please explain a guide about padding and prefixes." },
+  ]);
+  const codeReference = analyzePrompts([
+    {
+      text: [
+        "padding prefixes guide material",
+        "```",
+        "foo(bar)",
+        "```",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(prose.useful_prompts[0].categories, ["explanation"]);
+  assert.equal(codeReference.useful_prompt_count, 0);
+  assert.equal(codeReference.reference_prompt_count, 1);
+});
+
+test("English sentence starters survive artifact stripping", () => {
+  const requests = [
+    "For the login page, fix the validation.",
+    "If possible, please add error handling.",
+    "While you're working on this, please update the tests.",
+    "Return the filtered results and please explain the change.",
+    "Try opening the file and please analyze the failure.",
+    "From the documentation, please fix this integration.",
+    "Class definitions confuse me; please explain this behavior.",
+    "Import duties are unrelated; please update this module.",
+  ];
+  const prompts = requests.map((request) => ({
+    text: [
+      request,
+      "```js",
+      "export function validate(value) {",
+      "  if (!value) throw new Error('required');",
+      "  return value.trim();",
+      "}",
+      "```",
+    ].join("\n"),
+  }));
+  const analysis = analyzePrompts(prompts);
+
+  assert.equal(analysis.useful_prompt_count, requests.length);
+  assert.deepEqual(
+    analysis.useful_for_stats.map((prompt) => prompt.text),
+    requests,
+  );
+  assert.ok(analysis.useful_prompts.every((prompt) => prompt.artifact_origin === "unverified"));
+});
+
+test("moderate prompt templates cannot bypass provenance retention", () => {
+  const analysis = analyzePrompts([
+    {
+      text: [
+        "帮我完善这个模板",
+        "System prompt:",
+        "{{user_input}}",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.equal(analysis.useful_prompt_count, 0);
+  assert.equal(analysis.reference_prompt_count, 1);
+  assert.deepEqual(analysis.reference_summary.signals.artifact_kinds, {
+    prompt_template: 1,
+  });
+});
+
+test("analyzePrompts rejects short multi-line code without request prose", () => {
+  const analysis = analyzePrompts([
+    { text: "const first = items[0];\nlet second = items[1];" },
+  ]);
+
+  assert.equal(analysis.useful_prompt_count, 0);
+  assert.deepEqual(analysis.reference_summary.signals.artifact_kinds, { code: 1 });
+});
+
+test("reference reasons agree with declared artifact origin", () => {
+  const classification = classifyPrompt([
+    "这是我自己写的代码：",
+    "```js",
+    "const first = items[0];",
+    "let second = items[1];",
+    "```",
+  ].join("\n"));
+
+  assert.equal(classification.useful, false);
+  assert.equal(classification.artifact_origin, "user_authored");
+  assert.deepEqual(classification.reasons, ["user_authored_artifact_without_intent"]);
+});
+
+test("analyzePrompts recognizes config, diff, prompt-template, and opaque references", () => {
+  const analysis = analyzePrompts([
+    {
+      text: "```yaml\nserver:\n  host: localhost\n  port: 7681\nfeatures:\n  roast: true\n```",
+    },
+    {
+      text: [
+        "diff --git a/a.js b/a.js",
+        "index 123..456 100644",
+        "--- a/a.js",
+        "+++ b/a.js",
+        "@@ -1,2 +1,2 @@",
+        "-const value = oldValue;",
+        "+const value = newValue;",
+        "-renderOld();",
+        "+renderNew();",
+      ].join("\n"),
+    },
+    {
+      text: [
+        "System prompt:",
+        "You are an expert.",
+        "## Context",
+        "A generated context",
+        "## Instructions",
+        "Build the result",
+        "## Constraints",
+        "Use the template",
+        "## Output Format",
+        "JSON",
+      ].join("\n"),
+    },
+    { text: "A".repeat(1600) },
+  ]);
+
+  assert.equal(analysis.useful_prompt_count, 0);
+  assert.equal(analysis.reference_prompt_count, 4);
+  assert.equal(analysis.reference_summary.artifact_count, 4);
+  assert.equal(analysis.reference_summary.signals.artifact_kinds.config, 1);
+  assert.equal(analysis.reference_summary.signals.artifact_kinds.diff, 1);
+  assert.equal(analysis.reference_summary.signals.artifact_kinds.prompt_template, 1);
+  assert.equal(analysis.reference_summary.signals.artifact_kinds.opaque_text, 1);
+});
+
+test("analyzePrompts preserves ordinary Markdown requirement lists", () => {
+  const text = [
+    "请实现账户设置页面：",
+    "- 支持修改头像",
+    "- 添加邮箱验证",
+    "- 增加回归测试",
+    "- 优化移动端布局",
+  ].join("\n");
+  const analysis = analyzePrompts([{ text }]);
+
+  assert.equal(analysis.useful_prompt_count, 1);
+  assert.deepEqual(analysis.useful_prompts[0].artifact_kinds, []);
+  assert.equal(analysis.useful_for_stats[0].text, text);
+});
+
+test("analyzePrompts preserves pure Markdown lists and blockquotes", () => {
+  const list = [
+    "- 请实现头像修改",
+    "- 添加邮箱验证",
+    "- 增加回归测试",
+    "- 优化移动端布局",
+  ].join("\n");
+  const quote = [
+    "> Please explain the migration plan",
+    "> Please add rollback steps",
+    "> Keep the existing API stable",
+  ].join("\n");
+  const analysis = analyzePrompts([{ text: list }, { text: quote }]);
+
+  assert.equal(analysis.useful_prompt_count, 2);
+  assert.ok(analysis.useful_prompts.every((prompt) => prompt.artifact_kinds.length === 0));
+  assert.deepEqual(
+    analysis.useful_for_stats.map((prompt) => prompt.text),
+    [list, quote],
+  );
+});
+
+test("promptTextForCloud preserves natural-language import mentions", () => {
+  assert.equal(
+    promptTextForCloud("I want to import the library and also add types"),
+    "I want to import the library and also add types",
+  );
+  assert.equal(
+    promptTextForCloud("Keep this request\nimport { thing } from './module.js'\nand this explanation"),
+    "Keep this request\n \nand this explanation",
+  );
+  assert.equal(
+    promptTextForCloud(
+      "Keep this request\nimport React from 'react'\nWhat do you think about the performance?",
+    ),
+    "Keep this request\n \nWhat do you think about the performance?",
+  );
 });
 
 test("analyzePrompts extracts code and log signals from reference prompts", () => {

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -932,6 +932,27 @@ test("analyzePrompts removes successful stdout from single-command terminal atta
   );
 });
 
+test("analyzePrompts retains output-first terminal requests without a blank separator", () => {
+  const intent = "Please summarize the build result.";
+  const analysis = analyzePrompts([
+    {
+      text: [
+        "$ npm run build",
+        "vite v6.4.3 building for production...",
+        "dist/assets/index-R4nd0m.js 42.00 kB",
+        "✓ built in 812ms",
+        intent,
+      ].join("\n"),
+    },
+  ]);
+
+  assert.equal(analysis.useful_prompt_count, 1);
+  assert.equal(analysis.useful_for_stats[0].text, intent);
+  assert.deepEqual(analysis.useful_prompts[0].artifact_kinds, [
+    "terminal_output",
+  ]);
+});
+
 test("analyzePrompts removes unfenced code before category inference", () => {
   const intent = "Please explain this behavior.";
   const analysis = analyzePrompts([
@@ -981,6 +1002,29 @@ test("English testing categories include plural and inflected forms", () => {
       prompt.categories.includes("testing"),
     ),
   );
+});
+
+test("analyzePrompts recognizes write requests around code attachments", () => {
+  const intent = "Please write unit tests for this:";
+  const analysis = analyzePrompts([
+    {
+      text: [
+        intent,
+        "```js",
+        "export function sum(left, right) {",
+        "  return left + right;",
+        "}",
+        "```",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.equal(analysis.useful_prompt_count, 1);
+  assert.deepEqual(analysis.useful_prompts[0].categories, [
+    "testing",
+    "implementation",
+  ]);
+  assert.equal(analysis.useful_for_stats[0].text, intent);
 });
 
 test("English sentence starters survive artifact stripping", () => {

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -906,6 +906,32 @@ test("analyzePrompts removes ordinary stdout from terminal attachments", () => {
   );
 });
 
+test("analyzePrompts removes successful stdout from single-command terminal attachments", () => {
+  const intent = "Please summarize the build result.";
+  const analysis = analyzePrompts([
+    {
+      text: [
+        intent,
+        "$ npm run build",
+        "vite v6.4.3 building for production...",
+        "dist/assets/index-R4nd0m.js 42.00 kB",
+        "✓ built in 812ms",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.equal(analysis.useful_prompt_count, 1);
+  assert.deepEqual(analysis.useful_prompts[0].artifact_kinds, [
+    "terminal_output",
+  ]);
+  assert.equal(analysis.useful_for_stats[0].text, intent);
+  assert.ok(
+    !wordFrequencies(analysis.useful_for_stats).some((row) =>
+      ["vite", "dist", "assets", "r4nd0m"].includes(row.term),
+    ),
+  );
+});
+
 test("analyzePrompts removes unfenced code before category inference", () => {
   const intent = "Please explain this behavior.";
   const analysis = analyzePrompts([
@@ -940,6 +966,21 @@ test("English category and intent keywords require word boundaries", () => {
   assert.deepEqual(prose.useful_prompts[0].categories, ["explanation"]);
   assert.equal(codeReference.useful_prompt_count, 0);
   assert.equal(codeReference.reference_prompt_count, 1);
+});
+
+test("English testing categories include plural and inflected forms", () => {
+  const analysis = analyzePrompts([
+    { text: "Please write unit tests." },
+    { text: "Add specs for this module." },
+    { text: "The feature was tested with fixtures." },
+    { text: "Testing should cover the login flow." },
+  ]);
+
+  assert.ok(
+    analysis.useful_prompts.every((prompt) =>
+      prompt.categories.includes("testing"),
+    ),
+  );
 });
 
 test("English sentence starters survive artifact stripping", () => {

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -6,7 +6,10 @@ const os = require("node:os");
 const path = require("node:path");
 
 const { inspectSources } = require("../src/inspect");
-const { analyzePrompts, classifyPrompt } = require("../src/extract/prompt-analysis");
+const {
+  analyzePrompts,
+  classifyPrompt,
+} = require("../src/extract/prompt-analysis");
 const {
   tokenize,
   wordCloudRecords,
@@ -17,10 +20,16 @@ const { inspectEnvironment } = require("../src/extract/environment");
 const { dayBounds } = require("../src/lib/dates");
 const { extractCodexPrompt } = require("../src/sources/codex");
 const { extractClaudePrompt } = require("../src/sources/claude");
-const { extractCursorEntriesFromRows, inspectCursor } = require("../src/sources/cursor");
+const {
+  extractCursorEntriesFromRows,
+  inspectCursor,
+} = require("../src/sources/cursor");
 const { inspectTokenTracker } = require("../src/sources/token-tracker");
 const { codexUsageDelta } = require("../src/sources/codex");
-const { collectClaudeContextMessage, splitClaudeOutput } = require("../src/sources/claude");
+const {
+  collectClaudeContextMessage,
+  splitClaudeOutput,
+} = require("../src/sources/claude");
 
 const fixtures = path.join(__dirname, "fixtures");
 
@@ -57,7 +66,11 @@ test("inspectSources includes Codex, Claude, and Cursor when fixtures are presen
 
   assert.equal(report.summary.source_count, 3);
   assert.equal(report.summary.active_source_count, 3);
-  assert.deepEqual(report.summary.active_sources.sort(), ["claude", "codex", "cursor"]);
+  assert.deepEqual(report.summary.active_sources.sort(), [
+    "claude",
+    "codex",
+    "cursor",
+  ]);
   assert.equal(report.summary.prompt_count, 5);
   assert.equal(report.sources.codex.prompt_count, 2);
   assert.equal(report.sources.claude.prompt_count, 1);
@@ -92,7 +105,10 @@ test("inspectSources builds vibe_profile from multi-source prompts", async () =>
   assert.match(vibe.type_code, /^[MA][OP][VS][FX]$/);
   assert.equal(vibe.type_axes.length, 4);
   assert.ok(vibe.personality?.id);
-  assert.match(vibe.figure, /^\/assests\/characters-vibe-types\/.+-figure\.png$/);
+  assert.match(
+    vibe.figure,
+    /^\/assests\/characters-vibe-types\/.+-figure\.png$/,
+  );
   assert.equal(vibe.badge, null);
   assert.equal(vibe.dimensions.length, 6);
   assert.ok(!vibe.signals.some((signal) => signal.label === "Useful prompts"));
@@ -145,31 +161,43 @@ test("Cursor row parser treats cursorDiskKV type 1 bubbles as user prompts", () 
 });
 
 test("Codex prompt extractor ignores assistant messages", () => {
-  assert.equal(extractCodexPrompt({
-    payload: {
-      type: "assistant_message",
-      message: "我会先检查项目结构。",
-    },
-  }), "");
-  assert.equal(extractCodexPrompt({
-    payload: {
-      type: "user_message",
-      message: "帮我检查项目结构",
-    },
-  }), "帮我检查项目结构");
+  assert.equal(
+    extractCodexPrompt({
+      payload: {
+        type: "assistant_message",
+        message: "我会先检查项目结构。",
+      },
+    }),
+    "",
+  );
+  assert.equal(
+    extractCodexPrompt({
+      payload: {
+        type: "user_message",
+        message: "帮我检查项目结构",
+      },
+    }),
+    "帮我检查项目结构",
+  );
 });
 
 test("Claude prompt extractor ignores tool result content", () => {
-  assert.equal(extractClaudePrompt({
-    type: "user",
-    message: {
-      role: "user",
-      content: [
-        { type: "tool_result", content: "Fast-forward 13 files changed create mode 100644" },
-        { type: "text", text: "总结一下这次改动" },
-      ],
-    },
-  }), "总结一下这次改动");
+  assert.equal(
+    extractClaudePrompt({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            content: "Fast-forward 13 files changed create mode 100644",
+          },
+          { type: "text", text: "总结一下这次改动" },
+        ],
+      },
+    }),
+    "总结一下这次改动",
+  );
 });
 
 test("Cursor date range omits prompt rows without timestamps", async (t) => {
@@ -212,7 +240,10 @@ test("TokenTracker queue adapter aggregates hourly token buckets by day", async 
   assert.equal(report.bucket_count, 3);
   assert.equal(report.active_day_count, 2);
   assert.equal(report.token_totals.total_tokens, 5800);
-  assert.deepEqual(report.daily_rows.map((row) => row.day), ["2026-06-07", "2026-06-08"]);
+  assert.deepEqual(
+    report.daily_rows.map((row) => row.day),
+    ["2026-06-07", "2026-06-08"],
+  );
   assert.equal(report.daily_rows[0].total_tokens, 5000);
   assert.equal(report.daily_rows[0].conversation_count, 4);
   assert.equal(report.daily_rows[0].models["codex/gpt-5"], 1500);
@@ -258,7 +289,10 @@ test("Claude context assigns output across text, thinking, and tool blocks", () 
   ]);
 
   assert.equal(split.reasoning, 20);
-  assert.equal(split.messages + split.tool_calls + split.reasoning + split.custom_agents, 100);
+  assert.equal(
+    split.messages + split.tool_calls + split.reasoning + split.custom_agents,
+    100,
+  );
   assert.ok(split.tool_calls > split.messages);
   assert.equal(split.tool_call_count, 1);
 });
@@ -272,21 +306,42 @@ test("Claude context merges streaming snapshots before assigning usage", () => {
       usage: { input_tokens: 100, output_tokens: 20 },
     },
   };
-  collectClaudeContextMessage(messages, {
-    ...base,
-    message: { ...base.message, content: [{ type: "thinking", thinking: "plan" }] },
-  }, base.timestamp);
-  collectClaudeContextMessage(messages, {
-    ...base,
-    message: {
-      ...base.message,
-      content: [{ type: "tool_use", id: "tool-1", name: "Read", input: { file: "a" } }],
+  collectClaudeContextMessage(
+    messages,
+    {
+      ...base,
+      message: {
+        ...base.message,
+        content: [{ type: "thinking", thinking: "plan" }],
+      },
     },
-  }, base.timestamp);
+    base.timestamp,
+  );
+  collectClaudeContextMessage(
+    messages,
+    {
+      ...base,
+      message: {
+        ...base.message,
+        content: [
+          {
+            type: "tool_use",
+            id: "tool-1",
+            name: "Read",
+            input: { file: "a" },
+          },
+        ],
+      },
+    },
+    base.timestamp,
+  );
 
   const [message] = messages.values();
   assert.equal(messages.size, 1);
-  assert.deepEqual(message.content.map((block) => block.type), ["thinking", "tool_use"]);
+  assert.deepEqual(
+    message.content.map((block) => block.type),
+    ["thinking", "tool_use"],
+  );
   assert.equal(message.usage.output_tokens, 20);
 });
 
@@ -306,11 +361,17 @@ test("inspectSources exposes TokenTracker activity without adding synthetic prom
   assert.equal(report.activity.daily_rows.length, 2);
   assert.equal(report.activity.total_tokens, 5800);
   assert.equal(report.summary.prompt_count, 2);
-  assert.deepEqual(report.summary.active_sources, ["cursor", "codex", "claude"]);
+  assert.deepEqual(report.summary.active_sources, [
+    "cursor",
+    "codex",
+    "claude",
+  ]);
   assert.equal(report.summary.active_source_count, 3);
   assert.equal(report.sources["token-tracker"], undefined);
   assert.equal(report.vibe_profile.signals[0].label, "Total tokens");
-  assert.ok(!report.vibe_profile.signals.some((s) => s.label === "Useful prompts"));
+  assert.ok(
+    !report.vibe_profile.signals.some((s) => s.label === "Useful prompts"),
+  );
   assert.ok(report.activity.peak_day?.day);
   assert.ok(report.activity.longest_streak >= 1);
 });
@@ -326,7 +387,10 @@ test("inspectSources filters TokenTracker activity by date range", async () => {
     },
   });
 
-  assert.deepEqual(report.activity.daily_rows.map((row) => row.day), ["2026-06-08"]);
+  assert.deepEqual(
+    report.activity.daily_rows.map((row) => row.day),
+    ["2026-06-08"],
+  );
   assert.equal(report.activity.total_tokens, 800);
   assert.equal(report.activity.daily_rows[0].models["claude/sonnet"], 750);
 });
@@ -362,7 +426,9 @@ test("inspectSources computes useful high-frequency terms", async () => {
 
   const terms = report.word_frequencies.map((row) => row.term);
   assert.ok(terms.includes("token"));
-  assert.ok(report.word_frequencies.some((row) => row.key === "category:testing"));
+  assert.ok(
+    report.word_frequencies.some((row) => row.key === "category:testing"),
+  );
 });
 
 test("word cloud input excludes assistant and tool content", async () => {
@@ -377,11 +443,16 @@ test("word cloud input excludes assistant and tool content", async () => {
   });
 
   const blob = report.prompts.map((p) => p.text).join("\n");
-  assert.ok(!/xerophyte/i.test(blob), "assistant/tool xerophyte must not enter prompts");
+  assert.ok(
+    !/xerophyte/i.test(blob),
+    "assistant/tool xerophyte must not enter prompts",
+  );
   const terms = report.word_frequencies.map((row) => row.term);
   assert.ok(!terms.includes("xerophyte"));
   assert.ok(!terms.includes("xerophyte-followup"));
-  assert.ok(report.prompts.every((p) => p.source === "codex" || p.source === "claude"));
+  assert.ok(
+    report.prompts.every((p) => p.source === "codex" || p.source === "claude"),
+  );
   assert.ok(report.prompts.some((p) => /登录页面/.test(p.text)));
   assert.ok(report.prompts.some((p) => /根因/.test(p.text)));
 });
@@ -497,7 +568,9 @@ test("tokenize extracts session from Claude Code style identifiers", () => {
 });
 
 test("tokenize filters common UI state words from word cloud terms", () => {
-  const terms = tokenize("selectedSource provider model key className dashboard 发票 统计");
+  const terms = tokenize(
+    "selectedSource provider model key className dashboard 发票 统计",
+  );
 
   assert.ok(!terms.includes("selected"));
   assert.ok(!terms.includes("source"));
@@ -542,15 +615,25 @@ test("wordFrequencies merges common bilingual concept variants", () => {
 
   assert.equal(motion?.count, 4);
   assert.equal(motion?.prompt_count, 2);
-  assert.equal(words.filter((row) => ["动效", "animation", "motion"].includes(row.term)).length, 1);
+  assert.equal(
+    words.filter((row) => ["动效", "animation", "motion"].includes(row.term))
+      .length,
+    1,
+  );
 });
 
 test("wordCloudRecords preserves observed acronyms for domain discovery", () => {
   const [record] = wordCloudRecords([
-    { source: "cursor", timestamp: "2026-01-14T00:00:00Z", text: "继续做 HIT 和前庭分析界面" },
+    {
+      source: "cursor",
+      timestamp: "2026-01-14T00:00:00Z",
+      text: "继续做 HIT 和前庭分析界面",
+    },
   ]);
   const hit = record.concepts.find((concept) => concept.key === "term:hit");
-  const vestibular = record.concepts.find((concept) => concept.key === "term:前庭");
+  const vestibular = record.concepts.find(
+    (concept) => concept.key === "term:前庭",
+  );
 
   assert.equal(hit?.acronym, true);
   assert.equal(hit?.variants.HIT, 1);
@@ -579,7 +662,7 @@ test("wordFrequencies keeps natural language before inline code", () => {
       text: "U-Net架构可以引入代码块说明 import torch from torch import nn class convBlock(nn.Module): self.layer = nn.Sequential()",
     },
     {
-      text: "胶囊还是太大<div class=\"z-10\"><span fill=\"currentColor\">Klaviyo</span></div>",
+      text: '胶囊还是太大<div class="z-10"><span fill="currentColor">Klaviyo</span></div>',
     },
   ]).map((row) => row.term);
 
@@ -606,8 +689,14 @@ test("wordFrequencies strips local path fragments", () => {
 test("analyzePrompts separates useful intent from pasted code and logs", () => {
   const analysis = analyzePrompts([
     { source: "codex", text: "帮我修复登录 bug，并写一个回归测试" },
-    { source: "cursor", text: "SyntaxError: JSON.parse unexpected character at line 1 column 10\n    at reader.js:22890:16" },
-    { source: "claude", text: "const value = items.map((item) => item.id).join(',');\nreturn value;" },
+    {
+      source: "cursor",
+      text: "SyntaxError: JSON.parse unexpected character at line 1 column 10\n    at reader.js:22890:16",
+    },
+    {
+      source: "claude",
+      text: "const value = items.map((item) => item.id).join(',');\nreturn value;",
+    },
     { source: "codex", text: "先不要写代码，帮我设计一下方案" },
   ]);
 
@@ -644,11 +733,15 @@ test("analyzePrompts separates code authorship from surrounding request intent",
 
   assert.equal(analysis.useful_prompt_count, 2);
   assert.equal(analysis.reference_prompt_count, 0);
-  assert.deepEqual(analysis.useful_prompts[0].reasons, ["user_authored_artifact_with_intent"]);
+  assert.deepEqual(analysis.useful_prompts[0].reasons, [
+    "user_authored_artifact_with_intent",
+  ]);
   assert.equal(analysis.useful_prompts[0].artifact_origin, "user_authored");
   assert.deepEqual(analysis.useful_prompts[0].artifact_kinds, ["code"]);
   assert.equal(analysis.useful_prompts[0].category, "debugging");
-  assert.deepEqual(analysis.useful_prompts[1].reasons, ["user_intent_with_attached_reference"]);
+  assert.deepEqual(analysis.useful_prompts[1].reasons, [
+    "user_intent_with_attached_reference",
+  ]);
   assert.equal(analysis.useful_prompts[1].artifact_origin, "unverified");
   assert.equal(analysis.useful_for_stats[1].text, "请分析下面的 JavaScript。");
 });
@@ -672,7 +765,12 @@ test("analyzePrompts rejects app-owned prompt envelopes even when they contain J
 
   assert.equal(analysis.useful_prompt_count, 0);
   assert.equal(analysis.reference_prompt_count, 1);
-  assert.deepEqual(analysis.reference_summary.examples[0].text.startsWith("<recommended_plugins>"), true);
+  assert.deepEqual(
+    analysis.reference_summary.examples[0].text.startsWith(
+      "<recommended_plugins>",
+    ),
+    true,
+  );
 });
 
 test("analyzePrompts infers categories from request text instead of JavaScript identifiers", () => {
@@ -725,13 +823,19 @@ test("analyzePrompts separates intent from generated code and terminal output", 
   );
   assert.deepEqual(
     analysis.useful_prompts.map((prompt) => prompt.reasons[0]),
-    ["user_intent_with_external_reference", "user_intent_with_external_reference"],
+    [
+      "user_intent_with_external_reference",
+      "user_intent_with_external_reference",
+    ],
   );
   assert.deepEqual(
     analysis.useful_for_stats.map((prompt) => prompt.text),
     [generatedIntent, terminalIntent],
   );
-  assert.equal(analysis.average_useful_prompt_chars, Math.round((generatedIntent.length + terminalIntent.length) / 2));
+  assert.equal(
+    analysis.average_useful_prompt_chars,
+    Math.round((generatedIntent.length + terminalIntent.length) / 2),
+  );
   assert.equal(analysis.long_prompt_ratio, 0);
 });
 
@@ -752,7 +856,9 @@ test("analyzePrompts retains debugging intent around an unlabelled traceback", (
   assert.equal(analysis.useful_prompt_count, 1);
   assert.deepEqual(analysis.useful_prompts[0].categories, ["debugging"]);
   assert.equal(analysis.useful_prompts[0].artifact_origin, "unverified");
-  assert.deepEqual(analysis.useful_prompts[0].reasons, ["user_intent_with_attached_reference"]);
+  assert.deepEqual(analysis.useful_prompts[0].reasons, [
+    "user_intent_with_attached_reference",
+  ]);
   assert.equal(analysis.useful_for_stats[0].text, intent);
 });
 
@@ -793,7 +899,11 @@ test("analyzePrompts removes ordinary stdout from terminal attachments", () => {
   ]);
 
   assert.equal(analysis.useful_for_stats[0].text, intent);
-  assert.ok(!wordFrequencies(analysis.useful_for_stats).some((row) => row.term === "acme"));
+  assert.ok(
+    !wordFrequencies(analysis.useful_for_stats).some(
+      (row) => row.term === "acme",
+    ),
+  );
 });
 
 test("analyzePrompts removes unfenced code before category inference", () => {
@@ -821,12 +931,9 @@ test("English category and intent keywords require word boundaries", () => {
   ]);
   const codeReference = analyzePrompts([
     {
-      text: [
-        "padding prefixes guide material",
-        "```",
-        "foo(bar)",
-        "```",
-      ].join("\n"),
+      text: ["padding prefixes guide material", "```", "foo(bar)", "```"].join(
+        "\n",
+      ),
     },
   ]);
 
@@ -864,17 +971,17 @@ test("English sentence starters survive artifact stripping", () => {
     analysis.useful_for_stats.map((prompt) => prompt.text),
     requests,
   );
-  assert.ok(analysis.useful_prompts.every((prompt) => prompt.artifact_origin === "unverified"));
+  assert.ok(
+    analysis.useful_prompts.every(
+      (prompt) => prompt.artifact_origin === "unverified",
+    ),
+  );
 });
 
 test("moderate prompt templates cannot bypass provenance retention", () => {
   const analysis = analyzePrompts([
     {
-      text: [
-        "帮我完善这个模板",
-        "System prompt:",
-        "{{user_input}}",
-      ].join("\n"),
+      text: ["帮我完善这个模板", "System prompt:", "{{user_input}}"].join("\n"),
     },
   ]);
 
@@ -891,21 +998,27 @@ test("analyzePrompts rejects short multi-line code without request prose", () =>
   ]);
 
   assert.equal(analysis.useful_prompt_count, 0);
-  assert.deepEqual(analysis.reference_summary.signals.artifact_kinds, { code: 1 });
+  assert.deepEqual(analysis.reference_summary.signals.artifact_kinds, {
+    code: 1,
+  });
 });
 
 test("reference reasons agree with declared artifact origin", () => {
-  const classification = classifyPrompt([
-    "这是我自己写的代码：",
-    "```js",
-    "const first = items[0];",
-    "let second = items[1];",
-    "```",
-  ].join("\n"));
+  const classification = classifyPrompt(
+    [
+      "这是我自己写的代码：",
+      "```js",
+      "const first = items[0];",
+      "let second = items[1];",
+      "```",
+    ].join("\n"),
+  );
 
   assert.equal(classification.useful, false);
   assert.equal(classification.artifact_origin, "user_authored");
-  assert.deepEqual(classification.reasons, ["user_authored_artifact_without_intent"]);
+  assert.deepEqual(classification.reasons, [
+    "user_authored_artifact_without_intent",
+  ]);
 });
 
 test("analyzePrompts recognizes config, diff, prompt-template, and opaque references", () => {
@@ -948,8 +1061,14 @@ test("analyzePrompts recognizes config, diff, prompt-template, and opaque refere
   assert.equal(analysis.reference_summary.artifact_count, 4);
   assert.equal(analysis.reference_summary.signals.artifact_kinds.config, 1);
   assert.equal(analysis.reference_summary.signals.artifact_kinds.diff, 1);
-  assert.equal(analysis.reference_summary.signals.artifact_kinds.prompt_template, 1);
-  assert.equal(analysis.reference_summary.signals.artifact_kinds.opaque_text, 1);
+  assert.equal(
+    analysis.reference_summary.signals.artifact_kinds.prompt_template,
+    1,
+  );
+  assert.equal(
+    analysis.reference_summary.signals.artifact_kinds.opaque_text,
+    1,
+  );
 });
 
 test("analyzePrompts preserves ordinary Markdown requirement lists", () => {
@@ -982,7 +1101,11 @@ test("analyzePrompts preserves pure Markdown lists and blockquotes", () => {
   const analysis = analyzePrompts([{ text: list }, { text: quote }]);
 
   assert.equal(analysis.useful_prompt_count, 2);
-  assert.ok(analysis.useful_prompts.every((prompt) => prompt.artifact_kinds.length === 0));
+  assert.ok(
+    analysis.useful_prompts.every(
+      (prompt) => prompt.artifact_kinds.length === 0,
+    ),
+  );
   assert.deepEqual(
     analysis.useful_for_stats.map((prompt) => prompt.text),
     [list, quote],
@@ -995,7 +1118,9 @@ test("promptTextForCloud preserves natural-language import mentions", () => {
     "I want to import the library and also add types",
   );
   assert.equal(
-    promptTextForCloud("Keep this request\nimport { thing } from './module.js'\nand this explanation"),
+    promptTextForCloud(
+      "Keep this request\nimport { thing } from './module.js'\nand this explanation",
+    ),
     "Keep this request\n \nand this explanation",
   );
   assert.equal(
@@ -1010,7 +1135,7 @@ test("analyzePrompts extracts code and log signals from reference prompts", () =
   const analysis = analyzePrompts([
     {
       source: "cursor",
-      text: "src/App.tsx\n```tsx\nexport function App() { return <main className=\"page\">Hi</main>; }\n```",
+      text: 'src/App.tsx\n```tsx\nexport function App() { return <main className="page">Hi</main>; }\n```',
     },
     {
       source: "codex",
@@ -1042,7 +1167,10 @@ test("analyzePrompts counts all useful prompts even when useful prompt examples 
 
 test("inspectEnvironment counts skills, MCP servers, plugins, and custom instructions", async () => {
   const home = path.join(fixtures, "home");
-  const env = await inspectEnvironment({ home, codexHome: path.join(home, ".codex") });
+  const env = await inspectEnvironment({
+    home,
+    codexHome: path.join(home, ".codex"),
+  });
 
   assert.equal(env.codex.skills.count, 3);
   assert.equal(env.codex.skills.user_count, 2);

--- a/test/sources.test.js
+++ b/test/sources.test.js
@@ -10,7 +10,11 @@ const {
   extractCodexTokens,
   stripCodexInjectedContext,
 } = require("../src/sources/codex");
-const { inspectClaude, extractClaudePrompt, extractClaudeTokens } = require("../src/sources/claude");
+const {
+  inspectClaude,
+  extractClaudePrompt,
+  extractClaudeTokens,
+} = require("../src/sources/claude");
 const { inspectCursor, resolveCursorDbPath } = require("../src/sources/cursor");
 const { dayBounds } = require("../src/lib/dates");
 

--- a/test/sources.test.js
+++ b/test/sources.test.js
@@ -1,5 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
 const path = require("node:path");
 
 const {
@@ -66,6 +68,14 @@ Current URL: https://example.com/private
 检查主题词算法`),
     "检查主题词算法",
   );
+  assert.equal(
+    stripCodexInjectedContext(`<recommended_plugins>plugin noise</recommended_plugins>
+# AGENTS.md instructions
+<INSTRUCTIONS>Build with this generated JavaScript template.</INSTRUCTIONS>
+<environment_context>machine state</environment_context>
+这是我自己写的 JavaScript，请帮我修复重复提交。`),
+    "这是我自己写的 JavaScript，请帮我修复重复提交。",
+  );
 });
 
 test("extractCodexTokens normalizes total_token_usage", () => {
@@ -96,6 +106,27 @@ test("inspectCodex reads fixture session JSONL", async () => {
   assert.equal(report.prompt_count, 2);
   assert.equal(report.token_totals.total_tokens, 1800);
   assert.ok(report.prompts.every((p) => p.source === "codex"));
+});
+
+test("inspectCodex ignores non-rollout JSONL files", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vibe-roast-codex-"));
+  const row = JSON.stringify({
+    timestamp: "2026-06-07T10:00:00.000Z",
+    payload: { type: "user_message", message: "实现登录页" },
+  });
+  await fs.writeFile(path.join(root, "rollout-valid.jsonl"), `${row}\n`);
+  await fs.writeFile(path.join(root, "unrelated.jsonl"), `${row}\n`);
+
+  try {
+    const report = await inspectCodex({
+      root,
+      range: dayBounds("2026-06-07", "2026-06-07"),
+    });
+    assert.equal(report.files_scanned, 1);
+    assert.equal(report.prompt_count, 1);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
 });
 
 test("extractClaudePrompt only keeps user messages", () => {


### PR DESCRIPTION
## Summary

- separate actionable user intent from attached code, config, diffs, logs, terminal output, prompt templates, and opaque text
- track artifact provenance as user-authored, external/generated, unverified, or app-owned
- preserve common English and Chinese interrogative requests around attachments
- strip complete terminal-output regions and unfenced code before category and word-cloud analysis
- strip known Codex desktop context envelopes while preserving the authored request
- add fixture-backed regression coverage for mixed artifacts, short code, prompt templates, tracebacks, Markdown, terminal output, and Codex rollout discovery

## Impact

Only stripped user request prose affects categories, word statistics, average length, and long-prompt ratio. Attached stdout, code keywords, generated material, and app-owned envelopes no longer distort the profile.

## Validation

- npm test — 139 passed, 0 failed
- git diff --check